### PR TITLE
Refactor NuGet search with balanced results

### DIFF
--- a/NugetMcpServer.Tests/Common/SearchResultBalancerTests.cs
+++ b/NugetMcpServer.Tests/Common/SearchResultBalancerTests.cs
@@ -1,0 +1,40 @@
+using System.Collections.Generic;
+using System.Linq;
+using NuGetMcpServer.Common;
+using NuGetMcpServer.Services;
+using Xunit;
+
+namespace NugetMcpServer.Tests.Common;
+
+public class SearchResultBalancerTests
+{
+    private static PackageInfo P(string prefix, int index) => new PackageInfo { Id = $"{prefix}{index}", Version = "1.0" };
+
+    [Fact]
+    public void Balance_PrefersSmallerSets()
+    {
+        var set1 = new SearchResultSet("a", new List<PackageInfo>{P("A",1),P("A",2),P("A",3),P("A",4),P("A",5),P("A",6),P("A",7),P("A",8),P("A",9),P("A",10)});
+        var set2 = new SearchResultSet("b", new List<PackageInfo>());
+        var set3 = new SearchResultSet("c", new List<PackageInfo>());
+        for(int i=1;i<=100;i++) set3.Packages.Add(P("C",i));
+
+        var result = SearchResultBalancer.Balance(new[]{set1,set2,set3},10);
+
+        Assert.Equal(10, result.Count);
+        Assert.Equal(5, result.Count(p => p.Id.StartsWith("A")));
+        Assert.Equal(5, result.Count(p => p.Id.StartsWith("C")));
+    }
+
+    [Fact]
+    public void Balance_SingleSmallSetIncluded()
+    {
+        var small = new SearchResultSet("s", new List<PackageInfo>{P("S",1)});
+        var large = new SearchResultSet("l", new List<PackageInfo>());
+        for(int i=1;i<=20;i++) large.Packages.Add(P("L",i));
+
+        var result = SearchResultBalancer.Balance(new[]{small,large},10);
+
+        Assert.Equal(10, result.Count);
+        Assert.Contains(result, p => p.Id=="S1");
+    }
+}

--- a/NugetMcpServer/Common/SearchResultBalancer.cs
+++ b/NugetMcpServer/Common/SearchResultBalancer.cs
@@ -1,0 +1,42 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace NuGetMcpServer.Common;
+
+public record SearchResultSet(string Keyword, List<Services.PackageInfo> Packages);
+
+public static class SearchResultBalancer
+{
+    public static List<Services.PackageInfo> Balance(IEnumerable<SearchResultSet> sets, int maxResults)
+    {
+        var setList = sets.Where(s => s.Packages.Count > 0).ToList();
+        if (!setList.Any() || maxResults <= 0)
+            return [];
+
+        var sorted = setList.OrderBy(s => s.Packages.Count).ToList();
+        var indexes = sorted.ToDictionary(s => s, _ => 0);
+        var result = new List<Services.PackageInfo>();
+        var usedIds = new HashSet<string>(System.StringComparer.OrdinalIgnoreCase);
+
+        while (result.Count < maxResults && sorted.Any(s => indexes[s] < s.Packages.Count))
+        {
+            foreach (var set in sorted)
+            {
+                var idx = indexes[set];
+                if (idx >= set.Packages.Count)
+                    continue;
+
+                indexes[set] = idx + 1;
+                var pkg = set.Packages[idx];
+                if (usedIds.Add(pkg.Id))
+                {
+                    result.Add(pkg);
+                    if (result.Count >= maxResults)
+                        break;
+                }
+            }
+        }
+
+        return result;
+    }
+}


### PR DESCRIPTION
## Summary
- refactor `SearchPackagesTool` to balance results and handle fuzzy search
- add `SearchResultBalancer` helper
- test balancing logic

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68543d1224f8832a9d1b6a7d0bea71f2