### PR TITLE
Improve fuzzy search and balancing tests

### DIFF
--- a/NugetMcpServer.Tests/Common/SearchResultBalancerTests.cs
+++ b/NugetMcpServer.Tests/Common/SearchResultBalancerTests.cs
@@ -42,4 +42,17 @@ public class SearchResultBalancerTests
         Assert.Equal(10, result.Count);
         Assert.Contains(result, p => p.Id == "S1");
     }
+
+    [Fact]
+    public void Balance_RemovesDuplicates()
+    {
+        SearchResultSet set1 = new("a", [P("X", 1)]);
+        SearchResultSet set2 = new("b", [P("X", 1), P("Y", 1)]);
+
+        List<PackageInfo> result = SearchResultBalancer.Balance([set1, set2], 5);
+
+        Assert.Equal(2, result.Count);
+        Assert.Contains(result, p => p.Id == "X1");
+        Assert.Contains(result, p => p.Id == "Y1");
+    }
 }


### PR DESCRIPTION
## Summary
- expand stop words and add SearchContext for intermediate results
- refine fuzzy search workflow with direct, word, and AI stages
- simplify progress reporting
- add unit test ensuring duplicates are removed when balancing results

## Testing
- `dotnet test NugetMcpServer.Tests/NugetMcpServer.Tests.csproj -v diag` *(fails: .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_6854817bd318832aa12aa2c89de4169b