### PR TITLE
Apply refactoring recommendations

### DIFF
--- a/NugetMcpServer.Tests/Integration/McpServerIntegrationTests.cs
+++ b/NugetMcpServer.Tests/Integration/McpServerIntegrationTests.cs
@@ -108,7 +108,7 @@ public class McpServerIntegrationTests(ITestOutputHelper testOutput) : TestBase(
         var listTool = new ListInterfacesTool(toolLogger, packageService, archiveProcessingService);
 
         // Call the tool directly to verify the package contains interfaces
-        var result = await listTool.ListInterfaces("DimonSmart.MazeGenerator");
+        var result = await listTool.list_interfaces("DimonSmart.MazeGenerator");
 
         // Make sure we found interfaces
         Assert.NotNull(result);

--- a/NugetMcpServer.Tests/Services/MetaPackageDetectorDataDrivenTests.cs
+++ b/NugetMcpServer.Tests/Services/MetaPackageDetectorDataDrivenTests.cs
@@ -104,7 +104,7 @@ public class MetaPackageDetectorDataDrivenTests : TestBase
         }
 
         // Act
-        var result = await _listClassesTool.ListClasses(packageId, version);
+        var result = await _listClassesTool.list_classes(packageId, version);
 
         // Assert
         TestOutput.WriteLine($"Package: {packageId} v{version}");
@@ -150,7 +150,7 @@ public class MetaPackageDetectorDataDrivenTests : TestBase
         }
 
         // Act
-        var result = await _listInterfacesTool.ListInterfaces(packageId, version);
+        var result = await _listInterfacesTool.list_interfaces(packageId, version);
 
         // Assert
         TestOutput.WriteLine($"Package: {packageId} v{version}");

--- a/NugetMcpServer.Tests/Tools/FuzzySearchPackagesToolTests.cs
+++ b/NugetMcpServer.Tests/Tools/FuzzySearchPackagesToolTests.cs
@@ -24,26 +24,14 @@ public class FuzzySearchPackagesToolTests : TestBase
         _tool = new FuzzySearchPackagesTool(_toolLogger, searchService);
     }
 
-    [Fact]
-    public async Task FuzzySearchPackages_WithEmptyQuery_ThrowsArgumentException()
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task FuzzySearchPackages_InvalidQuery_ThrowsArgumentException(string query)
     {
-        // Arrange
-        const string query = "";
-
         // Act & Assert
         await Assert.ThrowsAsync<ArgumentException>(() =>
-            _tool.FuzzySearchPackages(null!, query));
-    }
-
-    [Fact]
-    public async Task FuzzySearchPackages_WithWhitespaceQuery_ThrowsArgumentException()
-    {
-        // Arrange
-        const string query = "   ";
-
-        // Act & Assert
-        await Assert.ThrowsAsync<ArgumentException>(() =>
-            _tool.FuzzySearchPackages(null!, query));
+            _tool.fuzzy_search_packages(null!, query));
     }
 
     [Fact]
@@ -56,7 +44,7 @@ public class FuzzySearchPackagesToolTests : TestBase
         // We expect this to fail because we don't have a real server
         // but the validation should still work
         await Assert.ThrowsAsync<ArgumentNullException>(() =>
-            _tool.FuzzySearchPackages(null!, query, maxResults));
+            _tool.fuzzy_search_packages(null!, query, maxResults));
     }
 
     [Fact]
@@ -69,6 +57,6 @@ public class FuzzySearchPackagesToolTests : TestBase
 
         // Act & Assert
         await Assert.ThrowsAsync<OperationCanceledException>(() =>
-            _tool.FuzzySearchPackages(null!, query, cancellationToken: cts.Token));
+            _tool.fuzzy_search_packages(null!, query, cancellationToken: cts.Token));
     }
 }

--- a/NugetMcpServer.Tests/Tools/GetClassDefinitionToolTests.cs
+++ b/NugetMcpServer.Tests/Tools/GetClassDefinitionToolTests.cs
@@ -33,7 +33,7 @@ public class GetClassDefinitionToolTests : TestBase
         var pointClassName = "Point";
         var version = await _packageService.GetLatestVersion(packageId);
 
-        var definition = await _defTool.GetClassDefinition(packageId, pointClassName, version);
+        var definition = await _defTool.get_class_definition(packageId, pointClassName, version);
 
         // Assert
         Assert.NotNull(definition);
@@ -52,7 +52,7 @@ public class GetClassDefinitionToolTests : TestBase
         var genericMazeClassName = "Maze";
         var version = await _packageService.GetLatestVersion(packageId);
 
-        var definition = await _defTool.GetClassDefinition(packageId, genericMazeClassName, version);
+        var definition = await _defTool.get_class_definition(packageId, genericMazeClassName, version);
 
         // Assert
         Assert.NotNull(definition);
@@ -75,7 +75,7 @@ public class GetClassDefinitionToolTests : TestBase
         var packageId = "DimonSmart.MazeGenerator";
 
         // Step 1: List classes in the package
-        var result = await listTool.ListClasses(packageId);
+        var result = await listTool.list_classes(packageId);
         Assert.NotNull(result);
         Assert.NotEmpty(result.Classes);
 
@@ -83,7 +83,7 @@ public class GetClassDefinitionToolTests : TestBase
         var mazeClass = result.Classes.FirstOrDefault(c => c.Name.StartsWith("Cell"));
         if (mazeClass != null)
         {
-            var definition = await _defTool.GetClassDefinition(
+            var definition = await _defTool.get_class_definition(
                 packageId,
                 mazeClass.Name,
                 result.Version);
@@ -105,7 +105,7 @@ public class GetClassDefinitionToolTests : TestBase
         var fullPointClassName = "DimonSmart.MazeGenerator.Point";
         var version = await _packageService.GetLatestVersion(packageId);
 
-        var definition = await _defTool.GetClassDefinition(packageId, fullPointClassName, version);
+        var definition = await _defTool.get_class_definition(packageId, fullPointClassName, version);
 
         // Assert
         Assert.NotNull(definition);
@@ -126,7 +126,7 @@ public class GetClassDefinitionToolTests : TestBase
         var className = "NonExistentClass";
         var version = await _packageService.GetLatestVersion(packageId);
 
-        var definition = await _defTool.GetClassDefinition(packageId, className, version);
+        var definition = await _defTool.get_class_definition(packageId, className, version);
 
         // Assert
         Assert.NotNull(definition);

--- a/NugetMcpServer.Tests/Tools/GetEnumDefinitionToolTests.cs
+++ b/NugetMcpServer.Tests/Tools/GetEnumDefinitionToolTests.cs
@@ -24,26 +24,15 @@ public class GetEnumDefinitionToolTests : TestBase
         _packageService = CreateNuGetPackageService();
     }
 
-    [Fact]
-    public async Task GetEnumDefinition_Should_ThrowArgumentNullException_When_PackageIdIsEmpty()
+    [Theory]
+    [InlineData("", "SomeEnum")]
+    [InlineData("SomePackage", "")]
+    public async Task GetEnumDefinition_InvalidArguments_ThrowsArgumentNullException(string packageId, string enumName)
     {
-        // Arrange
         var archiveService = new ArchiveProcessingService(_archiveLoggerMock.Object, _packageService);
         var tool = new GetEnumDefinitionTool(_loggerMock.Object, _packageService, _formattingServiceMock.Object, archiveService);
 
-        // Act & Assert
-        await Assert.ThrowsAsync<ArgumentNullException>(() => tool.GetEnumDefinition("", "SomeEnum"));
-    }
-
-    [Fact]
-    public async Task GetEnumDefinition_Should_ThrowArgumentNullException_When_EnumNameIsEmpty()
-    {
-        // Arrange
-        var archiveService = new ArchiveProcessingService(_archiveLoggerMock.Object, _packageService);
-        var tool = new GetEnumDefinitionTool(_loggerMock.Object, _packageService, _formattingServiceMock.Object, archiveService);
-
-        // Act & Assert
-        await Assert.ThrowsAsync<ArgumentNullException>(() => tool.GetEnumDefinition("SomePackage", ""));
+        await Assert.ThrowsAsync<ArgumentNullException>(() => tool.get_enum_definition(packageId, enumName));
     }
 
     // Integration tests for enum lookup with real packages
@@ -58,7 +47,7 @@ public class GetEnumDefinitionToolTests : TestBase
         var archiveService = new ArchiveProcessingService(_archiveLoggerMock.Object, packageService);
         var tool = new GetEnumDefinitionTool(_loggerMock.Object, packageService, formattingService, archiveService);
 
-        var definition = await tool.GetEnumDefinition(packageId, dataTypeEnumName);
+        var definition = await tool.get_enum_definition(packageId, dataTypeEnumName);
 
         // Assert
         Assert.NotNull(definition);
@@ -78,7 +67,7 @@ public class GetEnumDefinitionToolTests : TestBase
         var archiveService = new ArchiveProcessingService(_archiveLoggerMock.Object, packageService);
         var tool = new GetEnumDefinitionTool(_loggerMock.Object, packageService, formattingService, archiveService);
 
-        var definition = await tool.GetEnumDefinition(packageId, fullDataTypeEnumName);
+        var definition = await tool.get_enum_definition(packageId, fullDataTypeEnumName);
 
         // Assert
         Assert.NotNull(definition);

--- a/NugetMcpServer.Tests/Tools/GetInterfaceDefinitionToolTests.cs
+++ b/NugetMcpServer.Tests/Tools/GetInterfaceDefinitionToolTests.cs
@@ -34,7 +34,7 @@ namespace NuGetMcpServer.Tests.Tools
             var interfaceName = "ICell";
             var version = await _packageService.GetLatestVersion(packageId);
 
-            var definition = await _defTool.GetInterfaceDefinition(packageId, interfaceName, version);
+            var definition = await _defTool.get_interface_definition(packageId, interfaceName, version);
 
             // Assert
             Assert.NotNull(definition);
@@ -53,7 +53,7 @@ namespace NuGetMcpServer.Tests.Tools
             var genericMazeInterfaceName = "IMaze";
             var version = await _packageService.GetLatestVersion(packageId);
 
-            var definition = await _defTool.GetInterfaceDefinition(packageId, genericMazeInterfaceName, version);
+            var definition = await _defTool.get_interface_definition(packageId, genericMazeInterfaceName, version);
 
             Assert.NotNull(definition);
             Assert.Contains("interface", definition);
@@ -76,7 +76,7 @@ namespace NuGetMcpServer.Tests.Tools
             var packageId = "DimonSmart.MazeGenerator";
 
             // Step 1: List interfaces in the package
-            var result = await listTool.ListInterfaces(packageId);
+            var result = await listTool.list_interfaces(packageId);
             Assert.NotNull(result);
             Assert.NotEmpty(result.Interfaces);
 
@@ -84,7 +84,7 @@ namespace NuGetMcpServer.Tests.Tools
             var mazeInterface = result.Interfaces.FirstOrDefault(i => i.Name.StartsWith("IMaze"));
             if (mazeInterface != null)
             {
-                var definition = await _defTool.GetInterfaceDefinition(
+                var definition = await _defTool.get_interface_definition(
                     packageId,
                     mazeInterface.Name,
                     result.Version);
@@ -106,7 +106,7 @@ namespace NuGetMcpServer.Tests.Tools
             var fullICellInterfaceName = "DimonSmart.MazeGenerator.ICell";
             var version = await _packageService.GetLatestVersion(packageId);
 
-            var definition = await _defTool.GetInterfaceDefinition(packageId, fullICellInterfaceName, version);
+            var definition = await _defTool.get_interface_definition(packageId, fullICellInterfaceName, version);
 
             // Assert
             Assert.NotNull(definition);
@@ -126,7 +126,7 @@ namespace NuGetMcpServer.Tests.Tools
             var fullGenericMazeInterfaceName = "DimonSmart.MazeGenerator.IMaze";
             var version = await _packageService.GetLatestVersion(packageId);
 
-            var definition = await _defTool.GetInterfaceDefinition(packageId, fullGenericMazeInterfaceName, version);
+            var definition = await _defTool.get_interface_definition(packageId, fullGenericMazeInterfaceName, version);
 
             Assert.NotNull(definition);
             Assert.Contains("interface", definition);

--- a/NugetMcpServer.Tests/Tools/GetPackageInfoToolTests.cs
+++ b/NugetMcpServer.Tests/Tools/GetPackageInfoToolTests.cs
@@ -27,7 +27,7 @@ public class GetPackageInfoToolTests : TestBase
     [Fact]
     public async Task GetPackageInfo_WithValidPackage_ReturnsFormattedInfo()
     {
-        var result = await _tool.GetPackageInfo("Newtonsoft.Json", "13.0.3");
+        var result = await _tool.get_package_info("Newtonsoft.Json", "13.0.3");
 
         Assert.NotNull(result);
         Assert.Contains("Newtonsoft.Json", result);
@@ -38,7 +38,7 @@ public class GetPackageInfoToolTests : TestBase
     [Fact]
     public async Task GetPackageInfo_WithMetaPackage_ShowsMetaPackageWarning()
     {
-        var result = await _tool.GetPackageInfo("Microsoft.AspNetCore.All", "2.1.0");
+        var result = await _tool.get_package_info("Microsoft.AspNetCore.All", "2.1.0");
 
         Assert.NotNull(result);
         Assert.Contains("Microsoft.AspNetCore.All", result);
@@ -46,22 +46,18 @@ public class GetPackageInfoToolTests : TestBase
         Assert.Contains("Dependencies:", result);
     }
 
-    [Fact]
-    public async Task GetPackageInfo_WithNullPackageId_ThrowsArgumentNullException()
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public async Task GetPackageInfo_InvalidPackageId_ThrowsArgumentNullException(string? packageId)
     {
-        await Assert.ThrowsAsync<System.ArgumentNullException>(() => _tool.GetPackageInfo(null!));
-    }
-
-    [Fact]
-    public async Task GetPackageInfo_WithEmptyPackageId_ThrowsArgumentNullException()
-    {
-        await Assert.ThrowsAsync<System.ArgumentNullException>(() => _tool.GetPackageInfo(""));
+        await Assert.ThrowsAsync<System.ArgumentNullException>(() => _tool.get_package_info(packageId!));
     }
 
     [Fact]
     public async Task GetPackageInfo_WithoutVersion_UsesLatestVersion()
     {
-        var result = await _tool.GetPackageInfo("Newtonsoft.Json");
+        var result = await _tool.get_package_info("Newtonsoft.Json");
 
         Assert.NotNull(result);
         Assert.Contains("Newtonsoft.Json", result);

--- a/NugetMcpServer.Tests/Tools/ListClassesToolTests.cs
+++ b/NugetMcpServer.Tests/Tools/ListClassesToolTests.cs
@@ -32,7 +32,7 @@ public class ListClassesToolTests : TestBase
         // Test with a known package
         var packageId = "DimonSmart.MazeGenerator";
 
-        var result = await _listTool.ListClasses(packageId);
+        var result = await _listTool.list_classes(packageId);
 
         Assert.NotNull(result);
         Assert.Equal(packageId, result.PackageId);
@@ -55,7 +55,7 @@ public class ListClassesToolTests : TestBase
         var packageId = "DimonSmart.MazeGenerator";
         var version = await _packageService.GetLatestVersion(packageId);
 
-        var result = await _listTool.ListClasses(packageId, version);
+        var result = await _listTool.list_classes(packageId, version);
 
         // Assert
         Assert.NotNull(result);
@@ -71,7 +71,7 @@ public class ListClassesToolTests : TestBase
     {
         // Test that the result contains modifier information
         var packageId = "DimonSmart.MazeGenerator";
-        var result = await _listTool.ListClasses(packageId);
+        var result = await _listTool.list_classes(packageId);
 
         // Assert
         Assert.NotNull(result);

--- a/NugetMcpServer.Tests/Tools/ListInterfacesToolTests.cs
+++ b/NugetMcpServer.Tests/Tools/ListInterfacesToolTests.cs
@@ -32,7 +32,7 @@ namespace NuGetMcpServer.Tests.Tools
             // Test with a known package
             var packageId = "DimonSmart.MazeGenerator";
 
-            var result = await _listTool.ListInterfaces(packageId);
+            var result = await _listTool.list_interfaces(packageId);
 
             // Assert
             Assert.NotNull(result);
@@ -56,7 +56,7 @@ namespace NuGetMcpServer.Tests.Tools
             var packageId = "DimonSmart.MazeGenerator";
             var version = await _packageService.GetLatestVersion(packageId);
 
-            var result = await _listTool.ListInterfaces(packageId, version);
+            var result = await _listTool.list_interfaces(packageId, version);
 
             // Assert
             Assert.NotNull(result);

--- a/NugetMcpServer.Tests/Tools/SearchPackagesToolTests.cs
+++ b/NugetMcpServer.Tests/Tools/SearchPackagesToolTests.cs
@@ -32,7 +32,7 @@ public class SearchPackagesToolTests : TestBase
         const int maxResults = 5;
 
         // Act
-        var result = await _tool.SearchPackages(query, maxResults);
+        var result = await _tool.search_packages(query, maxResults);
 
         // Assert
         Assert.NotNull(result);
@@ -42,26 +42,13 @@ public class SearchPackagesToolTests : TestBase
         Assert.True(result.Packages.Count <= maxResults * 2); // Allow for some flexibility due to multiple searches
     }
 
-    [Fact]
-    public async Task SearchPackages_WithEmptyQuery_ThrowsArgumentException()
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task SearchPackages_InvalidQuery_ThrowsArgumentException(string query)
     {
-        // Arrange
-        const string query = "";
-
-        // Act & Assert
         await Assert.ThrowsAsync<ArgumentException>(() =>
-            _tool.SearchPackages(query));
-    }
-
-    [Fact]
-    public async Task SearchPackages_WithWhitespaceQuery_ThrowsArgumentException()
-    {
-        // Arrange
-        const string query = "   ";
-
-        // Act & Assert
-        await Assert.ThrowsAsync<ArgumentException>(() =>
-            _tool.SearchPackages(query));
+            _tool.search_packages(query));
     }
 
     [Fact]
@@ -72,7 +59,7 @@ public class SearchPackagesToolTests : TestBase
         const int maxResults = 10;
 
         // Act
-        var result = await _tool.SearchPackages(query, maxResults);
+        var result = await _tool.search_packages(query, maxResults);
 
         // Assert
         Assert.NotNull(result);
@@ -89,7 +76,7 @@ public class SearchPackagesToolTests : TestBase
         const int maxResults = 150; // Exceeds limit of 100
 
         // Act
-        var result = await _tool.SearchPackages(query, maxResults);
+        var result = await _tool.search_packages(query, maxResults);
 
         // Assert
         Assert.NotNull(result);
@@ -107,6 +94,6 @@ public class SearchPackagesToolTests : TestBase
 
         // Act & Assert
         await Assert.ThrowsAsync<OperationCanceledException>(() =>
-            _tool.SearchPackages(query, cancellationToken: cts.Token));
+            _tool.search_packages(query, cancellationToken: cts.Token));
     }
 }

--- a/NugetMcpServer/Tools/AnalyzePackageStructureTool.cs
+++ b/NugetMcpServer/Tools/AnalyzePackageStructureTool.cs
@@ -29,7 +29,7 @@ public class AnalyzePackageStructureTool(
 {
     [McpServerTool]
     [Description("Analyzes NuGet package structure to determine if it's a meta-package and lists its dependencies.")]
-    public Task<string> AnalyzePackageStructure(
+    public Task<string> analyze_package_structure(
         [Description("NuGet package ID")] string packageId,
         [Description("Package version (optional, defaults to latest)")] string? version = null,
         [Description("Progress notification for long-running operations")] IProgress<ProgressNotificationValue>? progress = null)

--- a/NugetMcpServer/Tools/FuzzySearchPackagesTool.cs
+++ b/NugetMcpServer/Tools/FuzzySearchPackagesTool.cs
@@ -24,7 +24,7 @@ public class FuzzySearchPackagesTool(ILogger<FuzzySearchPackagesTool> logger, Pa
 {
     [McpServerTool]
     [Description("Advanced fuzzy search for NuGet packages using AI-generated alternatives and word matching. Use this method when regular search doesn't return desired results. This method uses sampling and may provide broader but less precise results.")]
-    public Task<PackageSearchResult> FuzzySearchPackages(
+    public Task<PackageSearchResult> fuzzy_search_packages(
         IMcpServer thisServer,
         [Description("Description of the functionality you're looking for")] string query,
         [Description("Maximum number of results to return (default: 20, max: 100)")] int maxResults = 20,

--- a/NugetMcpServer/Tools/GetEnumDefinitionTool.cs
+++ b/NugetMcpServer/Tools/GetEnumDefinitionTool.cs
@@ -27,7 +27,7 @@ public class GetEnumDefinitionTool(
 {
     [McpServerTool]
     [Description("Extracts and returns the C# enum definition from a specified NuGet package.")]
-    public Task<string> GetEnumDefinition(
+    public Task<string> get_enum_definition(
         [Description("NuGet package ID")] string packageId,
         [Description("Enum name (short name like 'DayOfWeek' or full name like 'System.DayOfWeek')")] string enumName,
         [Description("Package version (optional, defaults to latest)")] string? version = null,

--- a/NugetMcpServer/Tools/GetPackageDependenciesTool.cs
+++ b/NugetMcpServer/Tools/GetPackageDependenciesTool.cs
@@ -25,7 +25,7 @@ public class GetPackageDependenciesTool(
 {
     [McpServerTool]
     [Description("Gets dependencies of a NuGet package to help understand what other packages contain the actual implementations.")]
-    public Task<string> GetPackageDependencies(
+    public Task<string> get_package_dependencies(
         [Description("NuGet package ID")] string packageId,
         [Description("Package version (optional, defaults to latest)")] string? version = null,
         [Description("Progress notification for long-running operations")] IProgress<ProgressNotificationValue>? progress = null)
@@ -94,7 +94,7 @@ public class GetPackageDependenciesTool(
                 result += "\nTo explore the actual implementations, try listing classes/interfaces from these dependencies:\n";
                 foreach (var dep in uniqueDependencies.Take(3))
                 {
-                    result += $"  - NuGet_list_classes(packageId=\"{dep.Id}\")\n";
+                    result += $"  - nuget_list_classes(packageId=\"{dep.Id}\")\n";
                 }
             }
         }

--- a/NugetMcpServer/Tools/GetPackageInfoTool.cs
+++ b/NugetMcpServer/Tools/GetPackageInfoTool.cs
@@ -23,7 +23,7 @@ public class GetPackageInfoTool(
 {
     [McpServerTool]
     [Description("Gets detailed information about a NuGet package including metadata, dependencies, and whether it's a meta-package.")]
-    public Task<string> GetPackageInfo(
+    public Task<string> get_package_info(
         [Description("NuGet package ID")] string packageId,
         [Description("Package version (optional, defaults to latest)")] string? version = null,
         [Description("Progress notification for long-running operations")] IProgress<ProgressNotificationValue>? progress = null)

--- a/NugetMcpServer/Tools/SearchPackagesTool.cs
+++ b/NugetMcpServer/Tools/SearchPackagesTool.cs
@@ -22,7 +22,7 @@ public class SearchPackagesTool(ILogger<SearchPackagesTool> logger, PackageSearc
 {
     [McpServerTool]
     [Description("Searches for NuGet packages by query and comma-separated keywords. Provides fast and precise search results.")]
-    public Task<PackageSearchResult> SearchPackages(
+    public Task<PackageSearchResult> search_packages(
         [Description("Description of the functionality you're looking for, or comma-separated keywords for targeted search")] string query,
         [Description("Maximum number of results to return (default: 20, max: 100)")] int maxResults = 20,
         IProgress<ProgressNotificationValue>? progress = null,

--- a/NugetMcpServer/Tools/TimeTool.cs
+++ b/NugetMcpServer/Tools/TimeTool.cs
@@ -10,7 +10,7 @@ public static class TimeTool
 {
     [McpServerTool]
     [Description("Returns the current server time in ISO 8601 format (YYYY-MM-DDThh:mm:ssZ).")]
-    public static string GetCurrentTime()
+    public static string get_current_time()
     {
         return DateTime.UtcNow.ToString("o");
     }

--- a/README.md
+++ b/README.md
@@ -94,27 +94,27 @@ The server uses the .NET Generic Host and includes:
 
 ### TimeTool
 
-- `GetCurrentTime()` - Returns the current server time in ISO 8601 format (YYYY-MM-DDThh:mm:ssZ)
+- `get_current_time()` - Returns the current server time in ISO 8601 format (YYYY-MM-DDThh:mm:ssZ)
 
 
 ### Interface Tools
 
-- `GetInterfaceDefinition(packageId, interfaceName?, version?)` - Gets the C# interface definition from a NuGet package. Parameters: packageId (NuGet package ID), interfaceName (optional, short name without namespace), version (optional, defaults to latest)
-- `ListInterfaces(packageId, version?)` - Lists all public interfaces in a NuGet package. Returns package ID, version, and the list of interfaces
+- `get_interface_definition(packageId, interfaceName?, version?)` - Gets the C# interface definition from a NuGet package. Parameters: packageId (NuGet package ID), interfaceName (optional, short name without namespace), version (optional, defaults to latest)
+- `list_interfaces(packageId, version?)` - Lists all public interfaces in a NuGet package. Returns package ID, version, and the list of interfaces
 
 
 ### Enum Tools
 
-- `GetEnumDefinition(packageId, enumName, version?)` - Gets the C# enum definition from a NuGet package. Parameters: packageId (NuGet package ID), enumName (short name without namespace), version (optional, defaults to latest)
+- `get_enum_definition(packageId, enumName, version?)` - Gets the C# enum definition from a NuGet package. Parameters: packageId (NuGet package ID), enumName (short name without namespace), version (optional, defaults to latest)
 
 ### Class Tools
 
-- `GetClassDefinition(packageId, className, version?)` - Gets the C# class definition from a NuGet package. Parameters: packageId (NuGet package ID), className (short or full name), version (optional, defaults to latest)
-- `ListClasses(packageId, version?)` - Lists all public classes in a NuGet package. Returns package ID, version, and the list of classes
+- `get_class_definition(packageId, className, version?)` - Gets the C# class definition from a NuGet package. Parameters: packageId (NuGet package ID), className (short or full name), version (optional, defaults to latest)
+- `list_classes(packageId, version?)` - Lists all public classes in a NuGet package. Returns package ID, version, and the list of classes
 
 ### Package Search Tools
 
-- `SearchPackages(query, maxResults?, fuzzySearch?)` - Searches for NuGet packages by description or functionality.
+- `search_packages(query, maxResults?, fuzzySearch?)` - Searches for NuGet packages by description or functionality.
   - **Standard search mode (fuzzySearch=false, default)**: Performs direct search for the full query and also searches each comma-separated keyword if provided
   - **Fuzzy search mode (fuzzySearch=true)**: Starts with the standard search and additionally tries each individual word and AI-generated package name alternatives
   - AI analyzes user's functional requirements and generates 3 most likely package names (e.g., "maze generation" → "MazeGenerator MazeBuilder MazeCreator")
@@ -123,11 +123,11 @@ The server uses the .NET Generic Host and includes:
 
 ### Package Information Tools
 
-- `GetPackageInfo(packageId, version?)` - Gets comprehensive information about a NuGet package including metadata, dependencies, and meta-package status. Shows clear warnings for meta-packages and guidance on where to find actual implementations.
+- `get_package_info(packageId, version?)` - Gets comprehensive information about a NuGet package including metadata, dependencies, and meta-package status. Shows clear warnings for meta-packages and guidance on where to find actual implementations.
 
 ### Package Dependencies
 
-- `GetPackageDependencies(packageId, version?)` - Gets the dependencies of a NuGet package to help understand what other packages contain the actual implementations
+- `get_package_dependencies(packageId, version?)` - Gets the dependencies of a NuGet package to help understand what other packages contain the actual implementations
 
 ## MCP Server Response Examples
 


### PR DESCRIPTION
## Summary
- rename public MCP tool methods to snake_case
- inline single-use helper methods
- consolidate duplicate argument tests using `[Theory]`
- update README for new method names

## Testing
- `dotnet build NugetMcpServer.sln` *(fails: NETSDK1045 unsupported target framework)*

------
https://chatgpt.com/codex/tasks/task_e_686fed41f0e8832a8df93468edd1631b