### PR TITLE
Add version history to package info

### DIFF
--- a/NugetMcpServer.Tests/Tools/GetPackageInfoToolTests.cs
+++ b/NugetMcpServer.Tests/Tools/GetPackageInfoToolTests.cs
@@ -61,4 +61,12 @@ public class GetPackageInfoToolTests : TestBase
         Assert.NotNull(result);
         Assert.Contains("Newtonsoft.Json", result);
     }
+
+    [Fact]
+    public async Task GetPackageInfo_IncludesVersionHistory()
+    {
+        var result = await _tool.get_package_info("Newtonsoft.Json", "13.0.3");
+
+        Assert.Contains("Recent versions:", result);
+    }
 }

--- a/NugetMcpServer/Tools/GetPackageInfoTool.cs
+++ b/NugetMcpServer/Tools/GetPackageInfoTool.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Threading.Tasks;
 
@@ -60,10 +61,12 @@ public class GetPackageInfoTool(
         progress.ReportMessage("Extracting package information");
         var packageInfo = PackageService.GetPackageInfoAsync(packageStream, packageId, version!);
 
-        return FormatPackageInfo(packageInfo);
+        var versions = await PackageService.GetLatestVersions(packageId);
+
+        return FormatPackageInfo(packageInfo, versions);
     }
 
-    private static string FormatPackageInfo(PackageInfo packageInfo)
+    private static string FormatPackageInfo(PackageInfo packageInfo, IReadOnlyList<string> versions)
     {
         var result = $"Package: {packageInfo.PackageId} v{packageInfo.Version}\n";
         result += new string('=', result.Length - 1) + "\n\n";
@@ -92,6 +95,11 @@ public class GetPackageInfoTool(
         if (!string.IsNullOrWhiteSpace(packageInfo.LicenseUrl))
         {
             result += $"License URL: {packageInfo.LicenseUrl}\n";
+        }
+
+        if (versions.Count > 0)
+        {
+            result += $"\nRecent versions: {string.Join(", ", versions)}\n";
         }
 
         if (packageInfo.Dependencies.Count == 0)


### PR DESCRIPTION
## Summary
- fetch package version history from nuget
- display recent versions in `GetPackageInfoTool`
- test that the version history is included in output

## Testing
- `dotnet test NugetMcpServer.sln` *(fails: NETSDK1045 - current SDK does not support target framework net9.0)*

------
https://chatgpt.com/codex/tasks/task_e_687e07635824832a86a8b4c2a72c09b6