### PR TITLE
Fix version order in package info

### DIFF
--- a/NugetMcpServer/Tools/GetPackageInfoTool.cs
+++ b/NugetMcpServer/Tools/GetPackageInfoTool.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Linq;
 using System.Threading.Tasks;
 
 using Microsoft.Extensions.Logging;
@@ -99,7 +100,8 @@ public class GetPackageInfoTool(
 
         if (versions.Count > 0)
         {
-            result += $"\nRecent versions: {string.Join(", ", versions)}\n";
+            var orderedVersions = versions.Reverse();
+            result += $"\nRecent versions: {string.Join(", ", orderedVersions)}\n";
         }
 
         if (packageInfo.Dependencies.Count == 0)


### PR DESCRIPTION
## Summary
- show recent versions newest first

## Testing
- `dotnet test` *(fails: Server executable not found / Exec format error)*

------
https://chatgpt.com/codex/tasks/task_e_687e2d343444832a97beafeb0822e5e1