### PR TITLE
Add struct and record support

### DIFF
--- a/NugetMcpServer.Tests/Services/ClassFormattingServiceTests.cs
+++ b/NugetMcpServer.Tests/Services/ClassFormattingServiceTests.cs
@@ -113,4 +113,23 @@ public class ClassFormattingServiceTests(ITestOutputHelper testOutput) : TestBas
         TestOutput.WriteLine(formattedCode);
         TestOutput.WriteLine("====================================================\n");
     }
+
+    public record TestRecord(int Value);
+    public record struct TestRecordStruct(int Value);
+
+    [Fact]
+    public void FormatClassDefinition_WithRecordClass_ReturnsRecordKeyword()
+    {
+        var type = typeof(TestRecord);
+        var formatted = _formattingService.FormatClassDefinition(type, "TestAsm", "TestPackage");
+        Assert.Contains("public record TestRecord", formatted);
+    }
+
+    [Fact]
+    public void FormatClassDefinition_WithRecordStruct_ReturnsRecordStructKeyword()
+    {
+        var type = typeof(TestRecordStruct);
+        var formatted = _formattingService.FormatClassDefinition(type, "TestAsm", "TestPackage");
+        Assert.Contains("public record struct TestRecordStruct", formatted);
+    }
 }

--- a/NugetMcpServer.Tests/Tools/GetClassDefinitionToolTests.cs
+++ b/NugetMcpServer.Tests/Tools/GetClassDefinitionToolTests.cs
@@ -36,7 +36,7 @@ public class GetClassDefinitionToolTests : TestBase
 
         // Assert
         Assert.NotNull(definition);
-        Assert.Contains("class", definition);
+        Assert.True(definition.Contains("class") || definition.Contains("record"));
         Assert.Contains("Point", definition);
 
         TestOutput.WriteLine("\n========== TEST OUTPUT: Point CLASS DEFINITION ==========");
@@ -55,7 +55,7 @@ public class GetClassDefinitionToolTests : TestBase
 
         // Assert
         Assert.NotNull(definition);
-        Assert.Contains("class", definition);
+        Assert.True(definition.Contains("class") || definition.Contains("record"));
         Assert.DoesNotContain("not found in package", definition);
 
         TestOutput.WriteLine("\n========== TEST OUTPUT: Maze CLASS DEFINITION ==========");
@@ -88,7 +88,7 @@ public class GetClassDefinitionToolTests : TestBase
                 result.Version);
 
             // Assert
-            Assert.Contains("class", definition);
+            Assert.True(definition.Contains("class") || definition.Contains("record"));
             Assert.Contains("Cell", definition);
 
             TestOutput.WriteLine("\n========== TEST OUTPUT: RESULT OF GetClassDefinition ==========");
@@ -108,7 +108,7 @@ public class GetClassDefinitionToolTests : TestBase
 
         // Assert
         Assert.NotNull(definition);
-        Assert.Contains("class", definition);
+        Assert.True(definition.Contains("class") || definition.Contains("record"));
         Assert.Contains("Point", definition);
         Assert.DoesNotContain("not found in package", definition);
 

--- a/NugetMcpServer/Services/ClassFormattingService.cs
+++ b/NugetMcpServer/Services/ClassFormattingService.cs
@@ -26,7 +26,11 @@ public class ClassFormattingService
         else if (classType.IsSealed && !classType.IsValueType)
             sb.Append("sealed ");
 
-        string typeKeyword = classType.IsValueType ? "struct" : "class";
+        string typeKeyword;
+        if (TypeFormattingHelpers.IsRecordType(classType))
+            typeKeyword = classType.IsValueType ? "record struct" : "record";
+        else
+            typeKeyword = classType.IsValueType ? "struct" : "class";
         sb.Append($"{typeKeyword} {TypeFormattingHelpers.FormatTypeName(classType)}");
 
         var baseTypeInfo = GetBaseTypeInfo(classType);

--- a/NugetMcpServer/Services/Formatters/RecordListResultFormatter.cs
+++ b/NugetMcpServer/Services/Formatters/RecordListResultFormatter.cs
@@ -1,0 +1,51 @@
+using System.Linq;
+using System.Text;
+using NuGetMcpServer.Extensions;
+
+namespace NuGetMcpServer.Services.Formatters;
+
+public static class RecordListResultFormatter
+{
+    public static string Format(this RecordListResult result)
+    {
+        var sb = new StringBuilder();
+        sb.Append(result.GetMetaPackageWarningIfAny());
+
+        if (result.ShouldShowMetaPackageWarningOnly(result.Records.Count))
+            return sb.ToString();
+
+        if (!result.IsMetaPackage)
+        {
+            sb.AppendLine($"Records from {result.PackageId} v{result.Version}");
+            sb.AppendLine(new string('=', $"Records from {result.PackageId} v{result.Version}".Length));
+            sb.AppendLine();
+        }
+
+        if (result.Records.Count == 0)
+        {
+            sb.AppendLine("No public records found in this package.");
+            return sb.ToString();
+        }
+
+        if (result.IsMetaPackage && result.Records.Count > 0)
+        {
+            sb.AppendLine("This meta-package also contains the following records:");
+            sb.AppendLine();
+        }
+
+        var grouped = result.Records.GroupBy(r => r.AssemblyName).OrderBy(g => g.Key);
+        foreach (var group in grouped)
+        {
+            sb.AppendLine($"## {group.Key}");
+            foreach (var rec in group.OrderBy(r => r.FullName))
+            {
+                var formattedName = rec.FullName.FormatGenericTypeName();
+                var suffix = rec.IsStruct ? " (struct)" : string.Empty;
+                sb.AppendLine($"- {formattedName}{suffix}");
+            }
+            sb.AppendLine();
+        }
+
+        return sb.ToString();
+    }
+}

--- a/NugetMcpServer/Services/Formatters/StructListResultFormatter.cs
+++ b/NugetMcpServer/Services/Formatters/StructListResultFormatter.cs
@@ -1,0 +1,50 @@
+using System.Linq;
+using System.Text;
+using NuGetMcpServer.Extensions;
+
+namespace NuGetMcpServer.Services.Formatters;
+
+public static class StructListResultFormatter
+{
+    public static string Format(this StructListResult result)
+    {
+        var sb = new StringBuilder();
+        sb.Append(result.GetMetaPackageWarningIfAny());
+
+        if (result.ShouldShowMetaPackageWarningOnly(result.Structs.Count))
+            return sb.ToString();
+
+        if (!result.IsMetaPackage)
+        {
+            sb.AppendLine($"Structs from {result.PackageId} v{result.Version}");
+            sb.AppendLine(new string('=', $"Structs from {result.PackageId} v{result.Version}".Length));
+            sb.AppendLine();
+        }
+
+        if (result.Structs.Count == 0)
+        {
+            sb.AppendLine("No public structs found in this package.");
+            return sb.ToString();
+        }
+
+        if (result.IsMetaPackage && result.Structs.Count > 0)
+        {
+            sb.AppendLine("This meta-package also contains the following structs:");
+            sb.AppendLine();
+        }
+
+        var grouped = result.Structs.GroupBy(s => s.AssemblyName).OrderBy(g => g.Key);
+        foreach (var group in grouped)
+        {
+            sb.AppendLine($"## {group.Key}");
+            foreach (var st in group.OrderBy(s => s.FullName))
+            {
+                var formattedName = st.FullName.FormatGenericTypeName();
+                sb.AppendLine($"- {formattedName}");
+            }
+            sb.AppendLine();
+        }
+
+        return sb.ToString();
+    }
+}

--- a/NugetMcpServer/Services/RecordInfo.cs
+++ b/NugetMcpServer/Services/RecordInfo.cs
@@ -1,0 +1,9 @@
+namespace NuGetMcpServer.Services;
+
+public class RecordInfo
+{
+    public string Name { get; set; } = string.Empty;
+    public string FullName { get; set; } = string.Empty;
+    public string AssemblyName { get; set; } = string.Empty;
+    public bool IsStruct { get; set; }
+}

--- a/NugetMcpServer/Services/RecordListResult.cs
+++ b/NugetMcpServer/Services/RecordListResult.cs
@@ -1,0 +1,8 @@
+using System.Collections.Generic;
+
+namespace NuGetMcpServer.Services;
+
+public class RecordListResult : PackageResultBase
+{
+    public List<RecordInfo> Records { get; set; } = [];
+}

--- a/NugetMcpServer/Services/StructInfo.cs
+++ b/NugetMcpServer/Services/StructInfo.cs
@@ -1,0 +1,8 @@
+namespace NuGetMcpServer.Services;
+
+public class StructInfo
+{
+    public string Name { get; set; } = string.Empty;
+    public string FullName { get; set; } = string.Empty;
+    public string AssemblyName { get; set; } = string.Empty;
+}

--- a/NugetMcpServer/Services/StructListResult.cs
+++ b/NugetMcpServer/Services/StructListResult.cs
@@ -1,0 +1,8 @@
+using System.Collections.Generic;
+
+namespace NuGetMcpServer.Services;
+
+public class StructListResult : PackageResultBase
+{
+    public List<StructInfo> Structs { get; set; } = [];
+}

--- a/NugetMcpServer/Services/TypeFormattingHelpers.cs
+++ b/NugetMcpServer/Services/TypeFormattingHelpers.cs
@@ -12,6 +12,16 @@ public static class TypeFormattingHelpers
 {
     public static string FormatTypeName(Type type) => type.FormatCSharpTypeName();
 
+    public static bool IsRecordType(Type type)
+    {
+        var equalityContract = type.GetProperty("EqualityContract", BindingFlags.NonPublic | BindingFlags.Instance);
+        var printMembers = type.GetMethod("PrintMembers", BindingFlags.NonPublic | BindingFlags.Instance);
+        if (printMembers == null)
+            return false;
+
+        return equalityContract != null || type.IsValueType;
+    }
+
     // Builds the 'where T : [constraints]' string for generic type parameters
     public static string GetGenericConstraints(Type type)
     {

--- a/NugetMcpServer/Tools/GetRecordDefinitionTool.cs
+++ b/NugetMcpServer/Tools/GetRecordDefinitionTool.cs
@@ -1,0 +1,113 @@
+using System;
+using System.ComponentModel;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using ModelContextProtocol;
+using ModelContextProtocol.Server;
+using NuGet.Packaging;
+using NuGetMcpServer.Common;
+using NuGetMcpServer.Extensions;
+using NuGetMcpServer.Services;
+using static NuGetMcpServer.Extensions.ExceptionHandlingExtensions;
+
+namespace NuGetMcpServer.Tools;
+
+[McpServerToolType]
+public class GetRecordDefinitionTool(
+    ILogger<GetRecordDefinitionTool> logger,
+    NuGetPackageService packageService,
+    ClassFormattingService formattingService,
+    ArchiveProcessingService archiveService) : McpToolBase<GetRecordDefinitionTool>(logger, packageService)
+{
+    [McpServerTool]
+    [Description("Extracts and returns the C# record definition from a specified NuGet package.")]
+    public Task<string> get_record_definition(
+        [Description("NuGet package ID")] string packageId,
+        [Description("Record name (short or full name)")] string recordName,
+        [Description("Package version (optional, defaults to latest)")] string? version = null,
+        [Description("Progress notification for long-running operations")] IProgress<ProgressNotificationValue>? progress = null)
+    {
+        using var progressNotifier = new ProgressNotifier(progress);
+        return ExecuteWithLoggingAsync(
+            () => GetRecordDefinitionCore(packageId, recordName, version, progressNotifier),
+            Logger,
+            "Error fetching record definition");
+    }
+
+    private async Task<string> GetRecordDefinitionCore(
+        string packageId,
+        string recordName,
+        string? version,
+        ProgressNotifier progress)
+    {
+        if (string.IsNullOrWhiteSpace(packageId))
+            throw new ArgumentNullException(nameof(packageId));
+
+        if (string.IsNullOrWhiteSpace(recordName))
+            throw new ArgumentNullException(nameof(recordName));
+
+        progress.ReportMessage("Resolving package version");
+
+        if (version.IsNullOrEmptyOrNullString())
+            version = await PackageService.GetLatestVersion(packageId);
+
+        Logger.LogInformation("Fetching record {RecordName} from package {PackageId} version {Version}", recordName, packageId, version!);
+
+        progress.ReportMessage($"Downloading package {packageId} v{version}");
+
+        using var packageStream = await PackageService.DownloadPackageAsync(packageId, version!, progress);
+
+        progress.ReportMessage("Extracting package information");
+        var packageInfo = PackageService.GetPackageInfoAsync(packageStream, packageId, version!);
+
+        var metaPackageWarning = MetaPackageHelper.CreateMetaPackageWarning(packageInfo, packageId, version!);
+
+        progress.ReportMessage("Scanning assemblies for record");
+
+        using var packageReader = new PackageArchiveReader(packageStream, leaveStreamOpen: true);
+        var dllFiles = ArchiveProcessingService.GetUniqueAssemblyFiles(packageReader);
+
+        foreach (var filePath in dllFiles)
+        {
+            var assemblyInfo = await archiveService.LoadAssemblyFromPackageFileAsync(packageReader, filePath);
+            if (assemblyInfo != null)
+            {
+                try
+                {
+                    var recordType = assemblyInfo.Types.FirstOrDefault(t => TypeFormattingHelpers.IsRecordType(t) && (t.Name == recordName || t.FullName == recordName || GenericMatch(t, recordName)));
+                    if (recordType != null)
+                    {
+                        progress.ReportMessage($"Record found: {recordName}");
+                        var formatted = formattingService.FormatClassDefinition(recordType, assemblyInfo.AssemblyName, packageId);
+                        return metaPackageWarning + formatted;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Logger.LogDebug(ex, "Error processing assembly {AssemblyName}", assemblyInfo.AssemblyName);
+                }
+            }
+        }
+
+        return metaPackageWarning + $"Record '{recordName}' not found in package {packageId}.";
+    }
+
+    private static bool GenericMatch(Type type, string name)
+    {
+        if (!type.IsGenericType)
+            return false;
+
+        var backtickIndex = type.Name.IndexOf('`');
+        if (backtickIndex > 0 && type.Name[..backtickIndex] == name)
+            return true;
+
+        if (type.FullName is { } fullName)
+        {
+            var fullBacktickIndex = fullName.IndexOf('`');
+            if (fullBacktickIndex > 0 && fullName[..fullBacktickIndex] == name)
+                return true;
+        }
+        return false;
+    }
+}

--- a/NugetMcpServer/Tools/GetStructDefinitionTool.cs
+++ b/NugetMcpServer/Tools/GetStructDefinitionTool.cs
@@ -1,0 +1,113 @@
+using System;
+using System.ComponentModel;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using ModelContextProtocol;
+using ModelContextProtocol.Server;
+using NuGet.Packaging;
+using NuGetMcpServer.Common;
+using NuGetMcpServer.Extensions;
+using NuGetMcpServer.Services;
+using static NuGetMcpServer.Extensions.ExceptionHandlingExtensions;
+
+namespace NuGetMcpServer.Tools;
+
+[McpServerToolType]
+public class GetStructDefinitionTool(
+    ILogger<GetStructDefinitionTool> logger,
+    NuGetPackageService packageService,
+    ClassFormattingService formattingService,
+    ArchiveProcessingService archiveService) : McpToolBase<GetStructDefinitionTool>(logger, packageService)
+{
+    [McpServerTool]
+    [Description("Extracts and returns the C# struct definition from a specified NuGet package.")]
+    public Task<string> get_struct_definition(
+        [Description("NuGet package ID")] string packageId,
+        [Description("Struct name (short or full name)")] string structName,
+        [Description("Package version (optional, defaults to latest)")] string? version = null,
+        [Description("Progress notification for long-running operations")] IProgress<ProgressNotificationValue>? progress = null)
+    {
+        using var progressNotifier = new ProgressNotifier(progress);
+        return ExecuteWithLoggingAsync(
+            () => GetStructDefinitionCore(packageId, structName, version, progressNotifier),
+            Logger,
+            "Error fetching struct definition");
+    }
+
+    private async Task<string> GetStructDefinitionCore(
+        string packageId,
+        string structName,
+        string? version,
+        ProgressNotifier progress)
+    {
+        if (string.IsNullOrWhiteSpace(packageId))
+            throw new ArgumentNullException(nameof(packageId));
+
+        if (string.IsNullOrWhiteSpace(structName))
+            throw new ArgumentNullException(nameof(structName));
+
+        progress.ReportMessage("Resolving package version");
+
+        if (version.IsNullOrEmptyOrNullString())
+            version = await PackageService.GetLatestVersion(packageId);
+
+        Logger.LogInformation("Fetching struct {StructName} from package {PackageId} version {Version}", structName, packageId, version!);
+
+        progress.ReportMessage($"Downloading package {packageId} v{version}");
+
+        using var packageStream = await PackageService.DownloadPackageAsync(packageId, version!, progress);
+
+        progress.ReportMessage("Extracting package information");
+        var packageInfo = PackageService.GetPackageInfoAsync(packageStream, packageId, version!);
+
+        var metaPackageWarning = MetaPackageHelper.CreateMetaPackageWarning(packageInfo, packageId, version!);
+
+        progress.ReportMessage("Scanning assemblies for struct");
+
+        using var packageReader = new PackageArchiveReader(packageStream, leaveStreamOpen: true);
+        var dllFiles = ArchiveProcessingService.GetUniqueAssemblyFiles(packageReader);
+
+        foreach (var filePath in dllFiles)
+        {
+            var assemblyInfo = await archiveService.LoadAssemblyFromPackageFileAsync(packageReader, filePath);
+            if (assemblyInfo != null)
+            {
+                try
+                {
+                    var structType = assemblyInfo.Types.FirstOrDefault(t => t.IsValueType && !t.IsEnum && (t.Name == structName || t.FullName == structName || GenericMatch(t, structName)));
+                    if (structType != null)
+                    {
+                        progress.ReportMessage($"Struct found: {structName}");
+                        var formatted = formattingService.FormatClassDefinition(structType, assemblyInfo.AssemblyName, packageId);
+                        return metaPackageWarning + formatted;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Logger.LogDebug(ex, "Error processing assembly {AssemblyName}", assemblyInfo.AssemblyName);
+                }
+            }
+        }
+
+        return metaPackageWarning + $"Struct '{structName}' not found in package {packageId}.";
+    }
+
+    private static bool GenericMatch(Type type, string name)
+    {
+        if (!type.IsGenericType)
+            return false;
+
+        var backtickIndex = type.Name.IndexOf('`');
+        if (backtickIndex > 0 && type.Name[..backtickIndex] == name)
+            return true;
+
+        if (type.FullName is { } fullName)
+        {
+            var fullBacktickIndex = fullName.IndexOf('`');
+            if (fullBacktickIndex > 0 && fullName[..fullBacktickIndex] == name)
+                return true;
+        }
+        return false;
+    }
+}

--- a/NugetMcpServer/Tools/ListRecordsTool.cs
+++ b/NugetMcpServer/Tools/ListRecordsTool.cs
@@ -1,0 +1,93 @@
+using System;
+using System.ComponentModel;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using ModelContextProtocol;
+using ModelContextProtocol.Server;
+using NuGet.Packaging;
+using NuGetMcpServer.Common;
+using NuGetMcpServer.Extensions;
+using NuGetMcpServer.Services;
+using static NuGetMcpServer.Extensions.ExceptionHandlingExtensions;
+
+namespace NuGetMcpServer.Tools;
+
+[McpServerToolType]
+public class ListRecordsTool(ILogger<ListRecordsTool> logger, NuGetPackageService packageService, ArchiveProcessingService archiveProcessingService) : McpToolBase<ListRecordsTool>(logger, packageService)
+{
+    private readonly ArchiveProcessingService _archiveProcessingService = archiveProcessingService;
+
+    [McpServerTool]
+    [Description("Lists all public records available in a specified NuGet package.")]
+    public Task<RecordListResult> list_records(
+        [Description("NuGet package ID")] string packageId,
+        [Description("Package version (optional, defaults to latest)")] string? version = null,
+        [Description("Progress notification for long-running operations")] IProgress<ProgressNotificationValue>? progress = null)
+    {
+        using var progressNotifier = new ProgressNotifier(progress);
+        return ExecuteWithLoggingAsync(
+            () => ListRecordsCore(packageId, version, progressNotifier),
+            Logger,
+            "Error listing records");
+    }
+
+    private async Task<RecordListResult> ListRecordsCore(string packageId, string? version, IProgressNotifier progress)
+    {
+        if (string.IsNullOrWhiteSpace(packageId))
+            throw new ArgumentNullException(nameof(packageId));
+
+        progress.ReportMessage("Resolving package version");
+
+        if (version.IsNullOrEmptyOrNullString())
+            version = await PackageService.GetLatestVersion(packageId);
+
+        Logger.LogInformation("Listing records from package {PackageId} version {Version}", packageId, version!);
+
+        progress.ReportMessage($"Downloading package {packageId} v{version}");
+
+        var result = new RecordListResult
+        {
+            PackageId = packageId,
+            Version = version!,
+            Records = []
+        };
+
+        using var packageStream = await PackageService.DownloadPackageAsync(packageId, version!, progress);
+
+        progress.ReportMessage("Extracting package information");
+        var packageInfo = PackageService.GetPackageInfoAsync(packageStream, packageId, version!);
+
+        result.IsMetaPackage = packageInfo.IsMetaPackage;
+        result.Dependencies = packageInfo.Dependencies;
+        result.Description = packageInfo.Description ?? string.Empty;
+
+        progress.ReportMessage("Scanning assemblies for records");
+        packageStream.Position = 0;
+        using var packageReader = new PackageArchiveReader(packageStream, leaveStreamOpen: true);
+
+        var loadedAssemblies = _archiveProcessingService.LoadAllAssembliesFromPackage(packageReader);
+
+        foreach (var assemblyInfo in loadedAssemblies)
+        {
+            var records = assemblyInfo.Types
+                .Where(t => TypeFormattingHelpers.IsRecordType(t) && t.IsPublic && !t.IsNested)
+                .ToList();
+
+            foreach (var rec in records)
+            {
+                result.Records.Add(new RecordInfo
+                {
+                    Name = rec.Name,
+                    FullName = rec.FullName ?? string.Empty,
+                    AssemblyName = assemblyInfo.AssemblyName,
+                    IsStruct = rec.IsValueType
+                });
+            }
+        }
+
+        progress.ReportMessage($"Record listing completed - Found {result.Records.Count} records");
+
+        return result;
+    }
+}

--- a/NugetMcpServer/Tools/ListStructsTool.cs
+++ b/NugetMcpServer/Tools/ListStructsTool.cs
@@ -1,0 +1,92 @@
+using System;
+using System.ComponentModel;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using ModelContextProtocol;
+using ModelContextProtocol.Server;
+using NuGet.Packaging;
+using NuGetMcpServer.Common;
+using NuGetMcpServer.Extensions;
+using NuGetMcpServer.Services;
+using static NuGetMcpServer.Extensions.ExceptionHandlingExtensions;
+
+namespace NuGetMcpServer.Tools;
+
+[McpServerToolType]
+public class ListStructsTool(ILogger<ListStructsTool> logger, NuGetPackageService packageService, ArchiveProcessingService archiveProcessingService) : McpToolBase<ListStructsTool>(logger, packageService)
+{
+    private readonly ArchiveProcessingService _archiveProcessingService = archiveProcessingService;
+
+    [McpServerTool]
+    [Description("Lists all public structs available in a specified NuGet package.")]
+    public Task<StructListResult> list_structs(
+        [Description("NuGet package ID")] string packageId,
+        [Description("Package version (optional, defaults to latest)")] string? version = null,
+        [Description("Progress notification for long-running operations")] IProgress<ProgressNotificationValue>? progress = null)
+    {
+        using var progressNotifier = new ProgressNotifier(progress);
+        return ExecuteWithLoggingAsync(
+            () => ListStructsCore(packageId, version, progressNotifier),
+            Logger,
+            "Error listing structs");
+    }
+
+    private async Task<StructListResult> ListStructsCore(string packageId, string? version, IProgressNotifier progress)
+    {
+        if (string.IsNullOrWhiteSpace(packageId))
+            throw new ArgumentNullException(nameof(packageId));
+
+        progress.ReportMessage("Resolving package version");
+
+        if (version.IsNullOrEmptyOrNullString())
+            version = await PackageService.GetLatestVersion(packageId);
+
+        Logger.LogInformation("Listing structs from package {PackageId} version {Version}", packageId, version!);
+
+        progress.ReportMessage($"Downloading package {packageId} v{version}");
+
+        var result = new StructListResult
+        {
+            PackageId = packageId,
+            Version = version!,
+            Structs = []
+        };
+
+        using var packageStream = await PackageService.DownloadPackageAsync(packageId, version!, progress);
+
+        progress.ReportMessage("Extracting package information");
+        var packageInfo = PackageService.GetPackageInfoAsync(packageStream, packageId, version!);
+
+        result.IsMetaPackage = packageInfo.IsMetaPackage;
+        result.Dependencies = packageInfo.Dependencies;
+        result.Description = packageInfo.Description ?? string.Empty;
+
+        progress.ReportMessage("Scanning assemblies for structs");
+        packageStream.Position = 0;
+        using var packageReader = new PackageArchiveReader(packageStream, leaveStreamOpen: true);
+
+        var loadedAssemblies = _archiveProcessingService.LoadAllAssembliesFromPackage(packageReader);
+
+        foreach (var assemblyInfo in loadedAssemblies)
+        {
+            var structs = assemblyInfo.Types
+                .Where(t => t.IsValueType && !t.IsEnum && t.IsPublic && !t.IsNested)
+                .ToList();
+
+            foreach (var st in structs)
+            {
+                result.Structs.Add(new StructInfo
+                {
+                    Name = st.Name,
+                    FullName = st.FullName ?? string.Empty,
+                    AssemblyName = assemblyInfo.AssemblyName
+                });
+            }
+        }
+
+        progress.ReportMessage($"Struct listing completed - Found {result.Structs.Count} structs");
+
+        return result;
+    }
+}

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ You can use this server with [OllamaChat](https://github.com/DimonSmart/OllamaCh
 
 ## Features
 
-- Real-time extraction of interfaces and enums from NuGet packages
+- Real-time extraction of interfaces, enums, structs and records from NuGet packages
 - **Smart package search with AI-enhanced keyword generation**
 - **Two-phase search: direct search + AI fallback for better results**
 - **Comma-separated keyword search for fast targeted results with balanced distribution**
@@ -112,6 +112,16 @@ The server uses the .NET Generic Host and includes:
 
 - `get_class_definition(packageId, className, version?)` - Gets the C# class definition from a NuGet package. Parameters: packageId (NuGet package ID), className (short or full name), version (optional, defaults to latest)
 - `list_classes(packageId, version?)` - Lists all public classes in a NuGet package. Returns package ID, version, and the list of classes
+
+### Struct Tools
+
+- `get_struct_definition(packageId, structName, version?)` - Gets the C# struct definition from a NuGet package. Parameters: packageId, structName, version (optional)
+- `list_structs(packageId, version?)` - Lists all public structs in a NuGet package. Returns package ID, version, and the list of structs
+
+### Record Tools
+
+- `get_record_definition(packageId, recordName, version?)` - Gets the C# record definition from a NuGet package. Parameters: packageId, recordName, version (optional)
+- `list_records(packageId, version?)` - Lists all public records in a NuGet package. Returns package ID, version, and the list of records
 
 ### Package Search Tools
 
@@ -274,7 +284,7 @@ You can use this MCP server with different development tools and AI assistants:
 - **GitHub Copilot**: Use as an MCP server to get accurate package information
 - **Other MCP Clients**: Any tool that supports the Model Context Protocol
 
-By using this server, developers and AI systems get real-time, accurate information about NuGet package interfaces and enums. This reduces the chance of outdated or wrong API suggestions.
+By using this server, developers and AI systems get real-time, accurate information about NuGet package interfaces, enums, structs, and records. This reduces the chance of outdated or wrong API suggestions.
 
 ## Benefits for AI Development
 


### PR DESCRIPTION
## Summary
- support C# records in type formatter
- add tools to list and get struct and record definitions
- expose struct/record list results
- document struct/record tools in README
- broaden GetClassDefinition tests to allow record types
- add tests for record formatting

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68867f6c0b84832a92c82aa3a187df8b