### PR TITLE
Add unified class/record tools

### DIFF
--- a/NugetMcpServer.Tests/Services/MetaPackageDetectorDataDrivenTests.cs
+++ b/NugetMcpServer.Tests/Services/MetaPackageDetectorDataDrivenTests.cs
@@ -103,7 +103,7 @@ public class MetaPackageDetectorDataDrivenTests : TestBase
         }
 
         // Act
-        var result = await _listClassesTool.list_classes(packageId, version);
+        var result = await _listClassesTool.list_classes_and_records(packageId, version);
 
         // Assert
         TestOutput.WriteLine($"Package: {packageId} v{version}");

--- a/NugetMcpServer.Tests/Tools/GetClassDefinitionToolTests.cs
+++ b/NugetMcpServer.Tests/Tools/GetClassDefinitionToolTests.cs
@@ -32,7 +32,7 @@ public class GetClassDefinitionToolTests : TestBase
         var pointClassName = "Point";
         var version = await _packageService.GetLatestVersion(packageId);
 
-        var definition = await _defTool.get_class_definition(packageId, pointClassName, version);
+        var definition = await _defTool.get_class_or_record_definition(packageId, pointClassName, version);
 
         // Assert
         Assert.NotNull(definition);
@@ -51,7 +51,7 @@ public class GetClassDefinitionToolTests : TestBase
         var genericMazeClassName = "Maze";
         var version = await _packageService.GetLatestVersion(packageId);
 
-        var definition = await _defTool.get_class_definition(packageId, genericMazeClassName, version);
+        var definition = await _defTool.get_class_or_record_definition(packageId, genericMazeClassName, version);
 
         // Assert
         Assert.NotNull(definition);
@@ -74,7 +74,7 @@ public class GetClassDefinitionToolTests : TestBase
         var packageId = "DimonSmart.MazeGenerator";
 
         // Step 1: List classes in the package
-        var result = await listTool.list_classes(packageId);
+        var result = await listTool.list_classes_and_records(packageId);
         Assert.NotNull(result);
         Assert.NotEmpty(result.Classes);
 
@@ -82,10 +82,7 @@ public class GetClassDefinitionToolTests : TestBase
         var mazeClass = result.Classes.FirstOrDefault(c => c.Name.StartsWith("Cell"));
         if (mazeClass != null)
         {
-            var definition = await _defTool.get_class_definition(
-                packageId,
-                mazeClass.Name,
-                result.Version);
+            var definition = await _defTool.get_class_or_record_definition(packageId, mazeClass.Name, result.Version);
 
             // Assert
             Assert.Contains("class", definition);
@@ -104,7 +101,7 @@ public class GetClassDefinitionToolTests : TestBase
         var fullPointClassName = "DimonSmart.MazeGenerator.Point";
         var version = await _packageService.GetLatestVersion(packageId);
 
-        var definition = await _defTool.get_class_definition(packageId, fullPointClassName, version);
+        var definition = await _defTool.get_class_or_record_definition(packageId, fullPointClassName, version);
 
         // Assert
         Assert.NotNull(definition);
@@ -125,7 +122,7 @@ public class GetClassDefinitionToolTests : TestBase
         var className = "NonExistentClass";
         var version = await _packageService.GetLatestVersion(packageId);
 
-        var definition = await _defTool.get_class_definition(packageId, className, version);
+        var definition = await _defTool.get_class_or_record_definition(packageId, className, version);
 
         // Assert
         Assert.NotNull(definition);

--- a/NugetMcpServer.Tests/Tools/ListClassesToolTests.cs
+++ b/NugetMcpServer.Tests/Tools/ListClassesToolTests.cs
@@ -31,7 +31,7 @@ public class ListClassesToolTests : TestBase
         // Test with a known package
         var packageId = "DimonSmart.MazeGenerator";
 
-        var result = await _listTool.list_classes(packageId);
+        var result = await _listTool.list_classes_and_records(packageId);
 
         Assert.NotNull(result);
         Assert.Equal(packageId, result.PackageId);
@@ -54,7 +54,7 @@ public class ListClassesToolTests : TestBase
         var packageId = "DimonSmart.MazeGenerator";
         var version = await _packageService.GetLatestVersion(packageId);
 
-        var result = await _listTool.list_classes(packageId, version);
+        var result = await _listTool.list_classes_and_records(packageId, version);
 
         // Assert
         Assert.NotNull(result);
@@ -70,7 +70,7 @@ public class ListClassesToolTests : TestBase
     {
         // Test that the result contains modifier information
         var packageId = "DimonSmart.MazeGenerator";
-        var result = await _listTool.list_classes(packageId);
+        var result = await _listTool.list_classes_and_records(packageId);
 
         // Assert
         Assert.NotNull(result);

--- a/NugetMcpServer/Tools/GetPackageDependenciesTool.cs
+++ b/NugetMcpServer/Tools/GetPackageDependenciesTool.cs
@@ -94,7 +94,7 @@ public class GetPackageDependenciesTool(
                 result += "\nTo explore the actual implementations, try listing classes/interfaces from these dependencies:\n";
                 foreach (var dep in uniqueDependencies.Take(3))
                 {
-                    result += $"  - nuget_list_classes(packageId=\"{dep.Id}\")\n";
+                    result += $"  - nuget_list_classes_and_records(packageId=\"{dep.Id}\")\n";
                 }
             }
         }

--- a/NugetMcpServer/Tools/ListClassesTool.cs
+++ b/NugetMcpServer/Tools/ListClassesTool.cs
@@ -23,8 +23,8 @@ public class ListClassesTool(ILogger<ListClassesTool> logger, NuGetPackageServic
 {
     private readonly ArchiveProcessingService _archiveProcessingService = archiveProcessingService;
     [McpServerTool]
-    [Description("Lists all public classes available in a specified NuGet package.")]
-    public Task<ClassListResult> list_classes(
+    [Description("Lists all public classes and records available in a specified NuGet package.")]
+    public Task<ClassListResult> list_classes_and_records(
         [Description("NuGet package ID")] string packageId,
         [Description("Package version (optional, defaults to latest)")] string? version = null,
         [Description("Progress notification for long-running operations")] IProgress<ProgressNotificationValue>? progress = null)
@@ -34,7 +34,7 @@ public class ListClassesTool(ILogger<ListClassesTool> logger, NuGetPackageServic
         return ExecuteWithLoggingAsync(
             () => ListClassesCore(packageId, version, progressNotifier),
             Logger,
-            "Error listing classes");
+            "Error listing classes and records");
     }
 
 
@@ -50,7 +50,7 @@ public class ListClassesTool(ILogger<ListClassesTool> logger, NuGetPackageServic
             version = await PackageService.GetLatestVersion(packageId);
         }
 
-        Logger.LogInformation("Listing classes from package {PackageId} version {Version}",
+        Logger.LogInformation("Listing classes and records from package {PackageId} version {Version}",
             packageId, version!);
 
         progress.ReportMessage($"Downloading package {packageId} v{version}");
@@ -71,7 +71,7 @@ public class ListClassesTool(ILogger<ListClassesTool> logger, NuGetPackageServic
         result.Dependencies = packageInfo.Dependencies;
         result.Description = packageInfo.Description ?? string.Empty;
 
-        progress.ReportMessage("Scanning assemblies for classes");
+        progress.ReportMessage("Scanning assemblies for classes/records");
         packageStream.Position = 0;
         using var packageReader = new PackageArchiveReader(packageStream, leaveStreamOpen: true);
 
@@ -97,7 +97,7 @@ public class ListClassesTool(ILogger<ListClassesTool> logger, NuGetPackageServic
             }
         }
 
-        progress.ReportMessage($"Class listing completed - Found {result.Classes.Count} classes");
+        progress.ReportMessage($"Class listing completed - Found {result.Classes.Count} classes/records");
 
         return result;
     }

--- a/README.md
+++ b/README.md
@@ -110,8 +110,8 @@ The server uses the .NET Generic Host and includes:
 
 ### Class Tools
 
-- `get_class_definition(packageId, className, version?)` - Gets the C# class definition from a NuGet package. Parameters: packageId (NuGet package ID), className (short or full name), version (optional, defaults to latest)
-- `list_classes(packageId, version?)` - Lists all public classes in a NuGet package. Returns package ID, version, and the list of classes
+- `get_class_or_record_definition(packageId, typeName, version?)` - Gets the C# class or record definition from a NuGet package. Parameters: packageId (NuGet package ID), typeName (short or full name), version (optional, defaults to latest)
+- `list_classes_and_records(packageId, version?)` - Lists all public classes and records in a NuGet package. Returns package ID, version, and the list of classes/records
 
 ### Package Search Tools
 


### PR DESCRIPTION
## Summary
- merge `get_class_definition` and `get_record_definition` into `get_class_or_record_definition`
- replace `list_classes`/`list_records` with `list_classes_and_records`
- update dependencies tool suggestions and README documentation
- adjust tests to use unified methods

## Testing
- `dotnet test NugetMcpServer.sln --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_6888841f9ebc832a8124fb862a572b91