### PR TITLE
Handle missing dependencies via metadata

### DIFF
--- a/NugetMcpServer/Extensions/TypeFormattingExtensions.cs
+++ b/NugetMcpServer/Extensions/TypeFormattingExtensions.cs
@@ -6,29 +6,29 @@ namespace NuGetMcpServer.Extensions
 {
     public static class TypeFormattingExtensions
     {
-        private static readonly Dictionary<Type, string> PrimitiveTypeMap = new()
+        private static readonly Dictionary<string, string> PrimitiveTypeMap = new()
         {
-            { typeof(int), "int" },
-            { typeof(string), "string" },
-            { typeof(bool), "bool" },
-            { typeof(double), "double" },
-            { typeof(float), "float" },
-            { typeof(long), "long" },
-            { typeof(short), "short" },
-            { typeof(byte), "byte" },
-            { typeof(char), "char" },
-            { typeof(object), "object" },
-            { typeof(decimal), "decimal" },
-            { typeof(void), "void" },
-            { typeof(ulong), "ulong" },
-            { typeof(uint), "uint" },
-            { typeof(ushort), "ushort" },
-            { typeof(sbyte), "sbyte" }
+            { typeof(int).FullName!, "int" },
+            { typeof(string).FullName!, "string" },
+            { typeof(bool).FullName!, "bool" },
+            { typeof(double).FullName!, "double" },
+            { typeof(float).FullName!, "float" },
+            { typeof(long).FullName!, "long" },
+            { typeof(short).FullName!, "short" },
+            { typeof(byte).FullName!, "byte" },
+            { typeof(char).FullName!, "char" },
+            { typeof(object).FullName!, "object" },
+            { typeof(decimal).FullName!, "decimal" },
+            { typeof(void).FullName!, "void" },
+            { typeof(ulong).FullName!, "ulong" },
+            { typeof(uint).FullName!, "uint" },
+            { typeof(ushort).FullName!, "ushort" },
+            { typeof(sbyte).FullName!, "sbyte" }
         };
 
         public static string FormatCSharpTypeName(this Type type)
         {
-            if (PrimitiveTypeMap.TryGetValue(type, out var mappedName))
+            if (PrimitiveTypeMap.TryGetValue(type.FullName ?? type.Name, out var mappedName))
             {
                 return mappedName;
             }

--- a/NugetMcpServer/NugetMcpServer.csproj
+++ b/NugetMcpServer/NugetMcpServer.csproj
@@ -22,8 +22,8 @@
         <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.7" />
         <PackageReference Include="ModelContextProtocol" Version="0.3.0-preview.2" />
         <PackageReference Include="NuGet.Packaging" Version="6.14.0" />
+        <PackageReference Include="System.Reflection.MetadataLoadContext" Version="10.0.0-preview.6.25358.103" />
         <PackageReference Include="System.Text.Json" Version="9.0.5" />
-        <PackageReference Include="Mono.Cecil" Version="0.11.4" />
     </ItemGroup>
 
 </Project>

--- a/NugetMcpServer/NugetMcpServer.csproj
+++ b/NugetMcpServer/NugetMcpServer.csproj
@@ -23,6 +23,7 @@
         <PackageReference Include="ModelContextProtocol" Version="0.3.0-preview.2" />
         <PackageReference Include="NuGet.Packaging" Version="6.14.0" />
         <PackageReference Include="System.Text.Json" Version="9.0.5" />
+        <PackageReference Include="Mono.Cecil" Version="0.11.4" />
     </ItemGroup>
 
 </Project>

--- a/NugetMcpServer/Services/ArchiveProcessingService.cs
+++ b/NugetMcpServer/Services/ArchiveProcessingService.cs
@@ -20,6 +20,7 @@ public record LoadedAssemblyInfo
     public Type[] Types { get; init; } = [];
     public string AssemblyName { get; init; } = string.Empty;
     public string FilePath { get; init; } = string.Empty;
+    public byte[] AssemblyBytes { get; init; } = Array.Empty<byte>();
 }
 
 public class ArchiveProcessingService(ILogger<ArchiveProcessingService> logger, NuGetPackageService packageService)
@@ -53,7 +54,8 @@ public class ArchiveProcessingService(ILogger<ArchiveProcessingService> logger, 
                 Assembly = assembly,
                 Types = types,
                 AssemblyName = assemblyName,
-                FilePath = filePath
+                FilePath = filePath,
+                AssemblyBytes = assemblyData
             };
         }
         catch (Exception ex)
@@ -89,7 +91,8 @@ public class ArchiveProcessingService(ILogger<ArchiveProcessingService> logger, 
                 Assembly = assembly,
                 Types = types,
                 AssemblyName = assemblyName,
-                FilePath = filePath
+                FilePath = filePath,
+                AssemblyBytes = assemblyData
             };
         }
         catch (Exception ex)

--- a/NugetMcpServer/Services/ClassFormattingService.cs
+++ b/NugetMcpServer/Services/ClassFormattingService.cs
@@ -3,27 +3,55 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Text;
-using Mono.Cecil;
+using System.IO;
 
 namespace NuGetMcpServer.Services;
 
 public class ClassFormattingService
 {
-    // Builds a string representation of a class, including its properties,
-    // methods, constants, delegates, and other public members
+    // Builds a string representation of a class using metadata-only reflection
+    // to avoid requiring all referenced assemblies to be present.
     public string FormatClassDefinition(Type classType, string assemblyName, string packageName, byte[]? assemblyBytes = null)
     {
-        try
+        if (assemblyBytes == null)
         {
-            return FormatClassDefinitionReflection(classType, assemblyName, packageName);
+            try
+            {
+                if (!string.IsNullOrEmpty(classType.Assembly.Location))
+                {
+                    assemblyBytes = File.ReadAllBytes(classType.Assembly.Location);
+                }
+            }
+            catch
+            {
+                // ignore and fall back to using the loaded type
+            }
         }
-        catch (Exception) when (assemblyBytes != null)
+
+        if (assemblyBytes != null)
         {
-            return FormatClassDefinitionMetadata(assemblyBytes, classType.FullName ?? classType.Name, assemblyName, packageName);
+            try
+            {
+                var corePath = typeof(object).Assembly.Location;
+                var resolver = new PathAssemblyResolver(new[] { corePath });
+                using var mlc = new MetadataLoadContext(resolver, typeof(object).Assembly.GetName().Name!);
+                var asm = mlc.LoadFromByteArray(assemblyBytes);
+                var metaType = asm.GetType(classType.FullName ?? classType.Name);
+                if (metaType != null)
+                {
+                    return FormatClassDefinitionInternal(metaType, assemblyName, packageName);
+                }
+            }
+            catch
+            {
+                // fall back to using the provided Type instance
+            }
         }
+
+        return FormatClassDefinitionInternal(classType, assemblyName, packageName);
     }
 
-    private static string FormatClassDefinitionReflection(Type classType, string assemblyName, string packageName)
+    private static string FormatClassDefinitionInternal(Type classType, string assemblyName, string packageName)
     {
         var header = $"/* C# CLASS FROM {assemblyName} (Package: {packageName}) */";
 
@@ -218,108 +246,4 @@ public class ClassFormattingService
         };
     }
 
-    private static string FormatClassDefinitionMetadata(byte[] assemblyBytes, string fullName, string assemblyName, string packageName)
-    {
-        var asm = Mono.Cecil.AssemblyDefinition.ReadAssembly(new System.IO.MemoryStream(assemblyBytes));
-        var typeDef = asm.MainModule.GetType(fullName.Replace('+', '/')) ?? asm.MainModule.Types.FirstOrDefault(t => t.FullName == fullName.Replace('+', '/'));
-        if (typeDef == null)
-            return $"/* C# CLASS FROM {assemblyName} (Package: {packageName}) */\n// Type '{fullName}' not found";
-
-        var sb = new StringBuilder().AppendLine($"/* C# CLASS FROM {assemblyName} (Package: {packageName}) */");
-
-        sb.Append("public ");
-        if (typeDef.IsAbstract && typeDef.IsSealed)
-            sb.Append("static ");
-        else if (typeDef.IsAbstract && !typeDef.IsInterface)
-            sb.Append("abstract ");
-        else if (typeDef.IsSealed && !typeDef.IsValueType)
-            sb.Append("sealed ");
-
-        string typeKeyword = IsRecordType(typeDef) ? (typeDef.IsValueType ? "record struct" : "record") : (typeDef.IsValueType ? "struct" : "class");
-        sb.Append($"{typeKeyword} {FormatTypeName(typeDef)}");
-
-        var baseTypes = new List<string>();
-        if (typeDef.BaseType != null && typeDef.BaseType.FullName != "System.Object")
-            baseTypes.Add(FormatTypeName(typeDef.BaseType));
-        foreach (var iface in typeDef.Interfaces.Select(i => i.InterfaceType))
-            baseTypes.Add(FormatTypeName(iface));
-        if (baseTypes.Count > 0)
-            sb.Append($" : {string.Join(", ", baseTypes)}");
-
-        sb.AppendLine().AppendLine("{");
-
-        foreach (var field in typeDef.Fields.Where(f => f.IsPublic && f.HasConstant))
-        {
-            sb.AppendLine($"    public const {FormatTypeName(field.FieldType)} {field.Name} = {field.Constant};");
-        }
-
-        foreach (var field in typeDef.Fields.Where(f => f.IsPublic && f.IsInitOnly && !f.IsLiteral))
-        {
-            var modifier = field.IsStatic ? "static readonly" : "readonly";
-            sb.AppendLine($"    public {modifier} {FormatTypeName(field.FieldType)} {field.Name};");
-        }
-
-        foreach (var prop in typeDef.Properties.Where(p => p.GetMethod?.IsPublic == true || p.SetMethod?.IsPublic == true))
-        {
-            sb.Append($"    public {FormatTypeName(prop.PropertyType)} {prop.Name} {{ ");
-            if (prop.GetMethod?.IsPublic == true) sb.Append("get; ");
-            if (prop.SetMethod?.IsPublic == true) sb.Append("set; ");
-            sb.AppendLine("}");
-        }
-
-        foreach (var method in typeDef.Methods.Where(m => m.IsPublic && !m.IsSpecialName))
-        {
-            var parameters = string.Join(", ", method.Parameters.Select(p => $"{FormatTypeName(p.ParameterType)} {p.Name}"));
-            sb.AppendLine($"    public {FormatTypeName(method.ReturnType)} {method.Name}({parameters});");
-        }
-
-        sb.AppendLine("}");
-        return sb.ToString();
-    }
-
-    private static bool IsRecordType(Mono.Cecil.TypeDefinition typeDef)
-    {
-        var printMembers = typeDef.Methods.FirstOrDefault(m => m.Name == "PrintMembers" && !m.IsPublic && !m.IsStatic);
-        if (printMembers == null)
-            return false;
-        return typeDef.Properties.Any(p => p.Name == "EqualityContract") || typeDef.IsValueType;
-    }
-
-    private static string FormatTypeName(Mono.Cecil.TypeReference type)
-    {
-        if (type is Mono.Cecil.GenericInstanceType git)
-        {
-            var name = git.ElementType.Name.Split('`')[0];
-            var args = string.Join(", ", git.GenericArguments.Select(FormatTypeName));
-            return $"{name}<{args}>";
-        }
-
-        if (type.IsGenericParameter)
-            return type.Name;
-
-        var primitive = type.FullName switch
-        {
-            "System.Int32" => "int",
-            "System.String" => "string",
-            "System.Boolean" => "bool",
-            "System.Double" => "double",
-            "System.Single" => "float",
-            "System.Int64" => "long",
-            "System.Int16" => "short",
-            "System.Byte" => "byte",
-            "System.Char" => "char",
-            "System.Object" => "object",
-            "System.Decimal" => "decimal",
-            "System.Void" => "void",
-            "System.UInt64" => "ulong",
-            "System.UInt32" => "uint",
-            "System.UInt16" => "ushort",
-            "System.SByte" => "sbyte",
-            _ => null
-        };
-        if (primitive != null)
-            return primitive;
-
-        return type.Name.Split('`')[0];
-    }
 }

--- a/NugetMcpServer/Tools/GetClassDefinitionTool.cs
+++ b/NugetMcpServer/Tools/GetClassDefinitionTool.cs
@@ -137,7 +137,7 @@ public class GetClassDefinitionTool(
                     if (classType != null)
                     {
                         progress.ReportMessage($"Class or record found: {typeName}");
-                        var formatted = formattingService.FormatClassDefinition(classType, assemblyInfo.AssemblyName, packageId);
+                        var formatted = formattingService.FormatClassDefinition(classType, assemblyInfo.AssemblyName, packageId, assemblyInfo.AssemblyBytes);
                         return metaPackageWarning + formatted;
                     }
                 }

--- a/NugetMcpServer/Tools/GetRecordDefinitionTool.cs
+++ b/NugetMcpServer/Tools/GetRecordDefinitionTool.cs
@@ -77,7 +77,7 @@ public class GetRecordDefinitionTool(
                 if (recordType != null)
                 {
                     progress.ReportMessage($"Record found: {recordName}");
-                    var formatted = formattingService.FormatClassDefinition(recordType, assemblyInfo.AssemblyName, packageId);
+                    var formatted = formattingService.FormatClassDefinition(recordType, assemblyInfo.AssemblyName, packageId, assemblyInfo.AssemblyBytes);
                     return metaPackageWarning + formatted;
                 }
             }

--- a/NugetMcpServer/Tools/GetStructDefinitionTool.cs
+++ b/NugetMcpServer/Tools/GetStructDefinitionTool.cs
@@ -79,7 +79,7 @@ public class GetStructDefinitionTool(
                     if (structType != null)
                     {
                         progress.ReportMessage($"Struct found: {structName}");
-                        var formatted = formattingService.FormatClassDefinition(structType, assemblyInfo.AssemblyName, packageId);
+                        var formatted = formattingService.FormatClassDefinition(structType, assemblyInfo.AssemblyName, packageId, assemblyInfo.AssemblyBytes);
                         return metaPackageWarning + formatted;
                     }
                 }


### PR DESCRIPTION
## Summary
- include assembly bytes when loading packages
- add Mono.Cecil to parse assemblies when reflection fails
- fallback to metadata-based class formatting
- pass assembly bytes in tools when formatting

## Testing
- `dotnet build NugetMcpServer.sln -c Release`
- `dotnet test NugetMcpServer.Tests/NugetMcpServer.Tests.csproj -c Release --no-build --filter "ClassFormattingServiceTests" --logger "console;verbosity=normal"`

------
https://chatgpt.com/codex/tasks/task_e_6888cd835758832a907e724c4c0c4ddf