### PR TITLE
Improve package assembly loading context

### DIFF
--- a/NugetMcpServer/Common/McpToolBase.cs
+++ b/NugetMcpServer/Common/McpToolBase.cs
@@ -1,8 +1,4 @@
 using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Reflection;
 using System.Threading.Tasks;
 
 using Microsoft.Extensions.Logging;
@@ -18,13 +14,5 @@ public abstract class McpToolBase<T>(ILogger<T> logger, NuGetPackageService pack
     protected readonly ILogger<T> Logger = logger;
     protected readonly NuGetPackageService PackageService = packageService;
 
-    protected async Task<(Assembly? assembly, Type[] types)> LoadAssemblyFromFileAsync(PackageArchiveReader packageReader, string filePath)
-    {
-        using var fileStream = packageReader.GetStream(filePath);
-        using var ms = new MemoryStream();
-        await fileStream.CopyToAsync(ms);
 
-        var assemblyData = ms.ToArray();
-        return PackageService.LoadAssemblyFromMemoryWithTypes(assemblyData);
-    }
 }

--- a/NugetMcpServer/Services/InMemoryAssemblyLoadContext.cs
+++ b/NugetMcpServer/Services/InMemoryAssemblyLoadContext.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using System.Runtime.Loader;
+
+namespace NuGetMcpServer.Services;
+
+/// <summary>
+/// AssemblyLoadContext that loads assemblies from an in-memory dictionary.
+/// </summary>
+internal sealed class InMemoryAssemblyLoadContext : AssemblyLoadContext
+{
+    private readonly IDictionary<string, byte[]> _assemblies;
+
+    public InMemoryAssemblyLoadContext(IDictionary<string, byte[]> assemblies)
+        : base(isCollectible: true)
+    {
+        _assemblies = assemblies;
+    }
+
+    protected override Assembly? Load(AssemblyName assemblyName)
+    {
+        var name = assemblyName.Name;
+        if (name != null && _assemblies.TryGetValue(name, out var bytes))
+        {
+            using var ms = new MemoryStream(bytes);
+            return LoadFromStream(ms);
+        }
+
+        return null;
+    }
+}

--- a/NugetMcpServer/Services/NuGetPackageService.cs
+++ b/NugetMcpServer/Services/NuGetPackageService.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Net.Http;
 using System.Reflection;
 using System.Text.Json;
+using System.Runtime.Loader;
 using System.Threading.Tasks;
 
 using Microsoft.Extensions.Logging;
@@ -67,11 +68,13 @@ public class NuGetPackageService(ILogger<NuGetPackageService> logger, HttpClient
         return new MemoryStream(response);
     }
 
-    public (Assembly? assembly, Type[] types) LoadAssemblyFromMemoryWithTypes(byte[] assemblyData)
+    public (Assembly? assembly, Type[] types) LoadAssemblyFromMemoryWithTypes(byte[] assemblyData, AssemblyLoadContext? loadContext = null)
     {
         try
         {
-            var assembly = Assembly.Load(assemblyData);
+            var assembly = loadContext == null
+                ? Assembly.Load(assemblyData)
+                : loadContext.LoadFromStream(new MemoryStream(assemblyData));
 
             try
             {
@@ -95,11 +98,13 @@ public class NuGetPackageService(ILogger<NuGetPackageService> logger, HttpClient
     }
 
 
-    public Assembly? LoadAssemblyFromMemory(byte[] assemblyData)
+    public Assembly? LoadAssemblyFromMemory(byte[] assemblyData, AssemblyLoadContext? loadContext = null)
     {
         try
         {
-            return Assembly.Load(assemblyData);
+            return loadContext == null
+                ? Assembly.Load(assemblyData)
+                : loadContext.LoadFromStream(new MemoryStream(assemblyData));
         }
         catch (Exception ex)
         {

--- a/NugetMcpServer/Tools/AnalyzePackageTool.cs
+++ b/NugetMcpServer/Tools/AnalyzePackageTool.cs
@@ -85,9 +85,9 @@ public class AnalyzePackageTool(ILogger<AnalyzePackageTool> logger, NuGetPackage
         };
 
         using var packageReader = new PackageArchiveReader(packageStream, leaveStreamOpen: true);
-        var loadedAssemblies = _archiveProcessingService.LoadAllAssembliesFromPackage(packageReader);
+        var loaded = _archiveProcessingService.LoadAllAssembliesFromPackage(packageReader);
 
-        foreach (var assemblyInfo in loadedAssemblies)
+        foreach (var assemblyInfo in loaded.Assemblies)
         {
             var classes = assemblyInfo.Types
                 .Where(t => t.IsClass && t.IsPublic && !t.IsNested)

--- a/NugetMcpServer/Tools/GetInterfaceDefinitionTool.cs
+++ b/NugetMcpServer/Tools/GetInterfaceDefinitionTool.cs
@@ -78,18 +78,15 @@ public class GetInterfaceDefinitionTool(
         progress.ReportMessage("Scanning assemblies for interface");
 
         using var packageReader = new PackageArchiveReader(packageStream, leaveStreamOpen: true);
-        var dllFiles = ArchiveProcessingService.GetUniqueAssemblyFiles(packageReader);
+        var loaded = await archiveService.LoadAllAssembliesFromPackageAsync(packageReader);
 
-        foreach (var filePath in dllFiles)
+        foreach (var assemblyInfo in loaded.Assemblies)
         {
-            progress.ReportMessage($"Scanning {System.IO.Path.GetFileName(filePath)}: {filePath}");
+            progress.ReportMessage($"Scanning {assemblyInfo.AssemblyName}: {assemblyInfo.FilePath}");
 
-            var assemblyInfo = await archiveService.LoadAssemblyFromPackageFileAsync(packageReader, filePath);
-            if (assemblyInfo != null)
+            try
             {
-                try
-                {
-                    var iface = assemblyInfo.Types
+                var iface = assemblyInfo.Types
                         .FirstOrDefault(t =>
                         {
                             if (!t.IsInterface)
@@ -135,17 +132,16 @@ public class GetInterfaceDefinitionTool(
                             return false;
                         });
 
-                    if (iface != null)
-                    {
-                        progress.ReportMessage($"Interface found: {interfaceName}");
-                        var formatted = formattingService.FormatInterfaceDefinition(iface, assemblyInfo.AssemblyName, packageId);
-                        return metaPackageWarning + formatted;
-                    }
-                }
-                catch (Exception ex)
+                if (iface != null)
                 {
-                    Logger.LogDebug(ex, "Error processing assembly {AssemblyName}", assemblyInfo.AssemblyName);
+                    progress.ReportMessage($"Interface found: {interfaceName}");
+                    var formatted = formattingService.FormatInterfaceDefinition(iface, assemblyInfo.AssemblyName, packageId);
+                    return metaPackageWarning + formatted;
                 }
+            }
+            catch (Exception ex)
+            {
+                Logger.LogDebug(ex, "Error processing assembly {AssemblyName}", assemblyInfo.AssemblyName);
             }
         }
 

--- a/NugetMcpServer/Tools/GetRecordDefinitionTool.cs
+++ b/NugetMcpServer/Tools/GetRecordDefinitionTool.cs
@@ -67,9 +67,9 @@ public class GetRecordDefinitionTool(
 
         packageStream.Position = 0;
         using var packageReader = new PackageArchiveReader(packageStream, leaveStreamOpen: true);
-        var assemblies = await archiveService.LoadAllAssembliesFromPackageAsync(packageReader);
+        var loaded = await archiveService.LoadAllAssembliesFromPackageAsync(packageReader);
 
-        foreach (var assemblyInfo in assemblies)
+        foreach (var assemblyInfo in loaded.Assemblies)
         {
             try
             {

--- a/NugetMcpServer/Tools/ListClassesTool.cs
+++ b/NugetMcpServer/Tools/ListClassesTool.cs
@@ -75,9 +75,9 @@ public class ListClassesTool(ILogger<ListClassesTool> logger, NuGetPackageServic
         packageStream.Position = 0;
         using var packageReader = new PackageArchiveReader(packageStream, leaveStreamOpen: true);
 
-        var loadedAssemblies = _archiveProcessingService.LoadAllAssembliesFromPackage(packageReader);
+        var loaded = _archiveProcessingService.LoadAllAssembliesFromPackage(packageReader);
 
-        foreach (var assemblyInfo in loadedAssemblies)
+        foreach (var assemblyInfo in loaded.Assemblies)
         {
             var classes = assemblyInfo.Types
                 .Where(t => t.IsClass && t.IsPublic && !t.IsNested)

--- a/NugetMcpServer/Tools/ListInterfacesTool.cs
+++ b/NugetMcpServer/Tools/ListInterfacesTool.cs
@@ -73,9 +73,9 @@ public class ListInterfacesTool(ILogger<ListInterfacesTool> logger, NuGetPackage
         packageStream.Position = 0;
         using var packageReader = new PackageArchiveReader(packageStream, leaveStreamOpen: true);
 
-        var loadedAssemblies = _archiveProcessingService.LoadAllAssembliesFromPackage(packageReader);
+        var loaded = _archiveProcessingService.LoadAllAssembliesFromPackage(packageReader);
 
-        foreach (var assemblyInfo in loadedAssemblies)
+        foreach (var assemblyInfo in loaded.Assemblies)
         {
             Logger.LogInformation("Processing archive entry: {AssemblyName}", assemblyInfo.AssemblyName);
 

--- a/NugetMcpServer/Tools/ListRecordsTool.cs
+++ b/NugetMcpServer/Tools/ListRecordsTool.cs
@@ -66,9 +66,9 @@ public class ListRecordsTool(ILogger<ListRecordsTool> logger, NuGetPackageServic
         packageStream.Position = 0;
         using var packageReader = new PackageArchiveReader(packageStream, leaveStreamOpen: true);
 
-        var loadedAssemblies = _archiveProcessingService.LoadAllAssembliesFromPackage(packageReader);
+        var loaded = _archiveProcessingService.LoadAllAssembliesFromPackage(packageReader);
 
-        foreach (var assemblyInfo in loadedAssemblies)
+        foreach (var assemblyInfo in loaded.Assemblies)
         {
             var records = assemblyInfo.Types
                 .Where(t => TypeFormattingHelpers.IsRecordType(t) && t.IsPublic && !t.IsNested)

--- a/NugetMcpServer/Tools/ListStructsTool.cs
+++ b/NugetMcpServer/Tools/ListStructsTool.cs
@@ -66,9 +66,9 @@ public class ListStructsTool(ILogger<ListStructsTool> logger, NuGetPackageServic
         packageStream.Position = 0;
         using var packageReader = new PackageArchiveReader(packageStream, leaveStreamOpen: true);
 
-        var loadedAssemblies = _archiveProcessingService.LoadAllAssembliesFromPackage(packageReader);
+        var loaded = _archiveProcessingService.LoadAllAssembliesFromPackage(packageReader);
 
-        foreach (var assemblyInfo in loadedAssemblies)
+        foreach (var assemblyInfo in loaded.Assemblies)
         {
             var structs = assemblyInfo.Types
                 .Where(t => t.IsValueType && !t.IsEnum && t.IsPublic && !t.IsNested)


### PR DESCRIPTION
## Summary
- return load context plus assembly info when loading all assemblies
- adjust tools for new `LoadedPackageAssemblies` container

## Testing
- `dotnet test NugetMcpServer.Tests/NugetMcpServer.Tests.csproj -v diag --no-build`

------
https://chatgpt.com/codex/tasks/task_e_6888ec27051c832a9cb77d66789e01be