### PR TITLE
Refactor assembly loading

### DIFF
--- a/NugetMcpServer/Tools/GetClassDefinitionTool.cs
+++ b/NugetMcpServer/Tools/GetClassDefinitionTool.cs
@@ -8,8 +8,6 @@ using Microsoft.Extensions.Logging;
 using ModelContextProtocol;
 using ModelContextProtocol.Server;
 
-using NuGet.Packaging;
-
 using NuGetMcpServer.Common;
 using NuGetMcpServer.Extensions;
 using NuGetMcpServer.Services;
@@ -58,32 +56,20 @@ public class GetClassDefinitionTool(
 
         progress.ReportMessage("Resolving package version");
 
-        if (version.IsNullOrEmptyOrNullString())
-        {
-            version = await PackageService.GetLatestVersion(packageId);
-        }
+        var (loaded, packageInfo, resolvedVersion) =
+            await archiveService.LoadPackageAssembliesAsync(packageId, version, progress);
 
-        Logger.LogInformation("Fetching class or record {ClassName} from package {PackageId} version {Version}",
-            typeName, packageId, version!);
+        Logger.LogInformation(
+            "Fetching class or record {ClassName} from package {PackageId} version {Version}",
+            typeName, packageId, resolvedVersion);
 
-        progress.ReportMessage($"Downloading package {packageId} v{version}");
-
-        using var packageStream = await PackageService.DownloadPackageAsync(packageId, version!, progress);
-
-        progress.ReportMessage("Extracting package information");
-        var packageInfo = PackageService.GetPackageInfoAsync(packageStream, packageId, version!);
-
-        var metaPackageWarning = MetaPackageHelper.CreateMetaPackageWarning(packageInfo, packageId, version!);
+        var metaPackageWarning = MetaPackageHelper.CreateMetaPackageWarning(packageInfo, packageId, resolvedVersion);
 
         progress.ReportMessage("Scanning assemblies for class/record");
 
-        using var packageReader = new PackageArchiveReader(packageStream, leaveStreamOpen: true);
-
-        var loaded = await archiveService.LoadAllAssembliesFromPackageAsync(packageReader);
-
         foreach (var assemblyInfo in loaded.Assemblies)
         {
-            progress.ReportMessage($"Scanning {assemblyInfo.AssemblyName}: {assemblyInfo.FilePath}");
+            progress.ReportMessage($"Scanning {assemblyInfo.FileName}: {assemblyInfo.PackagePath}");
             try
             {
                 var classType = assemblyInfo.Types
@@ -135,13 +121,13 @@ public class GetClassDefinitionTool(
                 if (classType != null)
                 {
                     progress.ReportMessage($"Class or record found: {typeName}");
-                    var formatted = formattingService.FormatClassDefinition(classType, assemblyInfo.AssemblyName, packageId, assemblyInfo.AssemblyBytes);
+                    var formatted = formattingService.FormatClassDefinition(classType, assemblyInfo.FileName, packageId, assemblyInfo.AssemblyBytes);
                     return metaPackageWarning + formatted;
                 }
             }
             catch (Exception ex)
             {
-                Logger.LogDebug(ex, "Error processing assembly {AssemblyName}", assemblyInfo.AssemblyName);
+                Logger.LogDebug(ex, "Error processing assembly {AssemblyName}", assemblyInfo.FileName);
             }
         }
 

--- a/NugetMcpServer/Tools/ListRecordsTool.cs
+++ b/NugetMcpServer/Tools/ListRecordsTool.cs
@@ -5,7 +5,6 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using ModelContextProtocol;
 using ModelContextProtocol.Server;
-using NuGet.Packaging;
 using NuGetMcpServer.Common;
 using NuGetMcpServer.Extensions;
 using NuGetMcpServer.Services;
@@ -37,36 +36,24 @@ public class ListRecordsTool(ILogger<ListRecordsTool> logger, NuGetPackageServic
         if (string.IsNullOrWhiteSpace(packageId))
             throw new ArgumentNullException(nameof(packageId));
 
-        progress.ReportMessage("Resolving package version");
+        var (loaded, packageInfo, resolvedVersion) =
+            await _archiveProcessingService.LoadPackageAssembliesAsync(packageId, version, progress);
 
-        if (version.IsNullOrEmptyOrNullString())
-            version = await PackageService.GetLatestVersion(packageId);
-
-        Logger.LogInformation("Listing records from package {PackageId} version {Version}", packageId, version!);
-
-        progress.ReportMessage($"Downloading package {packageId} v{version}");
+        Logger.LogInformation(
+            "Listing records from package {PackageId} version {Version}", packageId, resolvedVersion);
 
         var result = new RecordListResult
         {
             PackageId = packageId,
-            Version = version!,
+            Version = resolvedVersion,
             Records = []
         };
-
-        using var packageStream = await PackageService.DownloadPackageAsync(packageId, version!, progress);
-
-        progress.ReportMessage("Extracting package information");
-        var packageInfo = PackageService.GetPackageInfoAsync(packageStream, packageId, version!);
 
         result.IsMetaPackage = packageInfo.IsMetaPackage;
         result.Dependencies = packageInfo.Dependencies;
         result.Description = packageInfo.Description ?? string.Empty;
 
         progress.ReportMessage("Scanning assemblies for records");
-        packageStream.Position = 0;
-        using var packageReader = new PackageArchiveReader(packageStream, leaveStreamOpen: true);
-
-        var loaded = _archiveProcessingService.LoadAllAssembliesFromPackage(packageReader);
 
         foreach (var assemblyInfo in loaded.Assemblies)
         {
@@ -80,7 +67,7 @@ public class ListRecordsTool(ILogger<ListRecordsTool> logger, NuGetPackageServic
                 {
                     Name = rec.Name,
                     FullName = rec.FullName ?? string.Empty,
-                    AssemblyName = assemblyInfo.AssemblyName,
+                    AssemblyName = assemblyInfo.FileName,
                     IsStruct = rec.IsValueType
                 });
             }


### PR DESCRIPTION
## Summary
- centralize NuGet package assembly loading logic
- rename fields storing assembly file info for clarity
- use the new helper across all tools

## Testing
- `dotnet test NugetMcpServer.Tests/NugetMcpServer.Tests.csproj -v n` *(fails: Build failed with exit code 130)*

------
https://chatgpt.com/codex/tasks/task_e_68890b8147e8832aa3876f8b901cada6