### PR TITLE
Improve popular packages smoke test

### DIFF
--- a/NugetMcpServer.Tests/Helpers/TestLogger.cs
+++ b/NugetMcpServer.Tests/Helpers/TestLogger.cs
@@ -9,6 +9,9 @@ public class TestLogger<T>(ITestOutputHelper output) : ILogger<T>
 {
     private readonly ITestOutputHelper _output = output;
 
+    public record LogEntry(LogLevel Level, string Message, Exception? Exception);
+    public List<LogEntry> Entries { get; } = new();
+
     public IDisposable? BeginScope<TState>(TState state) where TState : notnull
     {
         return null;
@@ -21,7 +24,10 @@ public class TestLogger<T>(ITestOutputHelper output) : ILogger<T>
 
     public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
     {
-        _output.WriteLine($"[{logLevel}] {formatter(state, exception)}");
+        var message = formatter(state, exception);
+        Entries.Add(new LogEntry(logLevel, message, exception));
+
+        _output.WriteLine($"[{logLevel}] {message}");
 
         if (exception != null)
         {


### PR DESCRIPTION
## Summary
- make `LoadPopularPackages_NoErrors` data-driven so each package is tested individually
- capture log entries in `TestLogger` and assert no exceptions were logged
- output full list of detected classes, interfaces and enums for each package

## Testing
- `dotnet test NugetMcpServer.Tests/NugetMcpServer.Tests.csproj -v:m`

------
https://chatgpt.com/codex/tasks/task_e_6889ea4d6f3c832a8a5f1c72e6a34a15