### PR TITLE
Add nested class support

### DIFF
--- a/NugetMcpServer.Tests/Integration/PopularPackagesSmokeTests.cs
+++ b/NugetMcpServer.Tests/Integration/PopularPackagesSmokeTests.cs
@@ -151,15 +151,7 @@ public class PopularPackagesSmokeTests : TestBase
 
             var attrs = typeDef.Attributes;
 
-            bool isNested = (attrs & System.Reflection.TypeAttributes.NestedFamANDAssem) != 0 ||
-                            (attrs & System.Reflection.TypeAttributes.NestedAssembly) != 0 ||
-                            (attrs & System.Reflection.TypeAttributes.NestedPrivate) != 0 ||
-                            (attrs & System.Reflection.TypeAttributes.NestedFamily) != 0 ||
-                            (attrs & System.Reflection.TypeAttributes.NestedFamORAssem) != 0 ||
-                            (attrs & System.Reflection.TypeAttributes.NestedPublic) != 0;
 
-            if (isNested)
-                continue;
 
             bool isInterface = (attrs & System.Reflection.TypeAttributes.Interface) != 0;
 

--- a/NugetMcpServer.Tests/Services/ClassFormattingServiceTests.cs
+++ b/NugetMcpServer.Tests/Services/ClassFormattingServiceTests.cs
@@ -89,7 +89,7 @@ public class ClassFormattingServiceTests(ITestOutputHelper testOutput) : TestBas
 
         Assert.NotNull(formattedCode);
         Assert.Contains($"/* C# CLASS FROM {assemblyName} (Package: {packageName}) */", formattedCode);
-        Assert.Contains("public class MockGeneric<string>", formattedCode);
+        Assert.Contains("public class ClassFormattingServiceTests.MockGeneric<string>", formattedCode);
         Assert.Contains("CONSTANT_VALUE = 42", formattedCode);
         Assert.Contains("static readonly", formattedCode);
         Assert.Contains("string GetValue()", formattedCode);
@@ -122,7 +122,7 @@ public class ClassFormattingServiceTests(ITestOutputHelper testOutput) : TestBas
     {
         var type = typeof(TestRecord);
         var formatted = _formattingService.FormatClassDefinition(type, "TestAsm", "TestPackage");
-        Assert.Contains("public record TestRecord", formatted);
+        Assert.Contains("public record ClassFormattingServiceTests.TestRecord", formatted);
     }
 
     [Fact]
@@ -130,6 +130,6 @@ public class ClassFormattingServiceTests(ITestOutputHelper testOutput) : TestBas
     {
         var type = typeof(TestRecordStruct);
         var formatted = _formattingService.FormatClassDefinition(type, "TestAsm", "TestPackage");
-        Assert.Contains("public record struct TestRecordStruct", formatted);
+        Assert.Contains("public record struct ClassFormattingServiceTests.TestRecordStruct", formatted);
     }
 }

--- a/NugetMcpServer.Tests/Services/InterfaceFormattingServiceTests.cs
+++ b/NugetMcpServer.Tests/Services/InterfaceFormattingServiceTests.cs
@@ -51,7 +51,7 @@ public class InterfaceFormattingServiceTests : TestBase
 
         Assert.NotNull(formattedCode);
         Assert.Contains($"/* C# INTERFACE FROM {assemblyName} (Package: {packageName}) */", formattedCode);
-        Assert.Contains("public interface IMockGeneric<string>", formattedCode);
+        Assert.Contains("public interface InterfaceFormattingServiceTests.IMockGeneric<string>", formattedCode);
         Assert.Contains("string GetValue()", formattedCode);
         Assert.Contains("void SetValue(string value)", formattedCode);
     }
@@ -70,7 +70,7 @@ public class InterfaceFormattingServiceTests : TestBase
         TestOutput.WriteLine("=====================================================\n");
 
         Assert.NotNull(formattedCode);
-        Assert.Contains("public interface IMockGeneric<int>", formattedCode);
+        Assert.Contains("public interface InterfaceFormattingServiceTests.IMockGeneric<int>", formattedCode);
         Assert.Contains("int GetValue()", formattedCode);
         Assert.Contains("void SetValue(int value)", formattedCode);
     }

--- a/NugetMcpServer/Tools/AnalyzePackageTool.cs
+++ b/NugetMcpServer/Tools/AnalyzePackageTool.cs
@@ -72,7 +72,7 @@ public class AnalyzePackageTool(ILogger<AnalyzePackageTool> logger, NuGetPackage
         foreach (var assemblyInfo in loaded.Assemblies)
         {
             var classes = assemblyInfo.Types
-                .Where(t => t.IsClass && t.IsPublic && !t.IsNested)
+                .Where(t => t.IsClass && t.IsPublic)
                 .ToList();
 
             foreach (var cls in classes)

--- a/NugetMcpServer/Tools/ListClassesTool.cs
+++ b/NugetMcpServer/Tools/ListClassesTool.cs
@@ -64,7 +64,7 @@ public class ListClassesTool(ILogger<ListClassesTool> logger, NuGetPackageServic
         foreach (var assemblyInfo in loaded.Assemblies)
         {
             var classes = assemblyInfo.Types
-                .Where(t => t.IsClass && t.IsPublic && !t.IsNested)
+                .Where(t => t.IsClass && t.IsPublic)
                 .ToList();
 
             foreach (var cls in classes)

--- a/NugetMcpServer/Tools/ListRecordsTool.cs
+++ b/NugetMcpServer/Tools/ListRecordsTool.cs
@@ -58,7 +58,7 @@ public class ListRecordsTool(ILogger<ListRecordsTool> logger, NuGetPackageServic
         foreach (var assemblyInfo in loaded.Assemblies)
         {
             var records = assemblyInfo.Types
-                .Where(t => TypeFormattingHelpers.IsRecordType(t) && t.IsPublic && !t.IsNested)
+                .Where(t => TypeFormattingHelpers.IsRecordType(t) && t.IsPublic)
                 .ToList();
 
             foreach (var rec in records)

--- a/NugetMcpServer/Tools/ListStructsTool.cs
+++ b/NugetMcpServer/Tools/ListStructsTool.cs
@@ -58,7 +58,7 @@ public class ListStructsTool(ILogger<ListStructsTool> logger, NuGetPackageServic
         foreach (var assemblyInfo in loaded.Assemblies)
         {
             var structs = assemblyInfo.Types
-                .Where(t => t.IsValueType && !t.IsEnum && t.IsPublic && !t.IsNested)
+                .Where(t => t.IsValueType && !t.IsEnum && t.IsPublic)
                 .ToList();
 
             foreach (var st in structs)


### PR DESCRIPTION
## Summary
- include nested classes, structs and records when listing types
- display nested type names with parent type prefix
- adjust format helpers to show nested names
- update tests for new nested type formatting

## Testing
- `dotnet test --logger "console;verbosity=normal"`

------
https://chatgpt.com/codex/tasks/task_e_6889fc158828832aabbc98678414e265