### PR TITLE
Include nested types when listing public members

### DIFF
--- a/NugetMcpServer/Tools/AnalyzePackageTool.cs
+++ b/NugetMcpServer/Tools/AnalyzePackageTool.cs
@@ -72,7 +72,7 @@ public class AnalyzePackageTool(ILogger<AnalyzePackageTool> logger, NuGetPackage
         foreach (var assemblyInfo in loaded.Assemblies)
         {
             var classes = assemblyInfo.Types
-                .Where(t => t.IsClass && t.IsPublic)
+                .Where(t => t.IsClass && (t.IsPublic || t.IsNestedPublic))
                 .ToList();
 
             foreach (var cls in classes)

--- a/NugetMcpServer/Tools/GetClassDefinitionTool.cs
+++ b/NugetMcpServer/Tools/GetClassDefinitionTool.cs
@@ -75,7 +75,7 @@ public class GetClassDefinitionTool(
                 var classType = assemblyInfo.Types
                         .FirstOrDefault(t =>
                         {
-                            if (!t.IsClass || !t.IsPublic)
+                            if (!t.IsClass || !(t.IsPublic || t.IsNestedPublic))
                             {
                                 return false;
                             }

--- a/NugetMcpServer/Tools/ListClassesTool.cs
+++ b/NugetMcpServer/Tools/ListClassesTool.cs
@@ -64,7 +64,7 @@ public class ListClassesTool(ILogger<ListClassesTool> logger, NuGetPackageServic
         foreach (var assemblyInfo in loaded.Assemblies)
         {
             var classes = assemblyInfo.Types
-                .Where(t => t.IsClass && t.IsPublic)
+                .Where(t => t.IsClass && (t.IsPublic || t.IsNestedPublic))
                 .ToList();
 
             foreach (var cls in classes)

--- a/NugetMcpServer/Tools/ListInterfacesTool.cs
+++ b/NugetMcpServer/Tools/ListInterfacesTool.cs
@@ -65,7 +65,7 @@ public class ListInterfacesTool(ILogger<ListInterfacesTool> logger, NuGetPackage
             Logger.LogInformation("Processing archive entry: {AssemblyName}", assemblyInfo.FileName);
 
             var interfaces = assemblyInfo.Types
-                .Where(t => t.IsInterface && t.IsPublic)
+                .Where(t => t.IsInterface && (t.IsPublic || t.IsNestedPublic))
                 .ToList();
 
             Logger.LogInformation("Found {InterfaceCount} interfaces in {AssemblyName}", interfaces.Count, assemblyInfo.FileName);

--- a/NugetMcpServer/Tools/ListRecordsTool.cs
+++ b/NugetMcpServer/Tools/ListRecordsTool.cs
@@ -58,7 +58,7 @@ public class ListRecordsTool(ILogger<ListRecordsTool> logger, NuGetPackageServic
         foreach (var assemblyInfo in loaded.Assemblies)
         {
             var records = assemblyInfo.Types
-                .Where(t => TypeFormattingHelpers.IsRecordType(t) && t.IsPublic)
+                .Where(t => TypeFormattingHelpers.IsRecordType(t) && (t.IsPublic || t.IsNestedPublic))
                 .ToList();
 
             foreach (var rec in records)

--- a/NugetMcpServer/Tools/ListStructsTool.cs
+++ b/NugetMcpServer/Tools/ListStructsTool.cs
@@ -58,7 +58,7 @@ public class ListStructsTool(ILogger<ListStructsTool> logger, NuGetPackageServic
         foreach (var assemblyInfo in loaded.Assemblies)
         {
             var structs = assemblyInfo.Types
-                .Where(t => t.IsValueType && !t.IsEnum && t.IsPublic)
+                .Where(t => t.IsValueType && !t.IsEnum && (t.IsPublic || t.IsNestedPublic))
                 .ToList();
 
             foreach (var st in structs)


### PR DESCRIPTION
## Summary
- include nested classes when scanning assemblies
- support nested records, structs, interfaces
- update class search to allow nested types

## Testing
- `dotnet test NugetMcpServer.Tests/NugetMcpServer.Tests.csproj --verbosity minimal` *(fails: Failed: 1, Passed: 118)*

------
https://chatgpt.com/codex/tasks/task_e_688a1264bb80832aa96e383d9ade94d0