### PR TITLE
Fix class loading without extra dependencies

### DIFF
--- a/NugetMcpServer/Extensions/TypeFormattingExtensions.cs
+++ b/NugetMcpServer/Extensions/TypeFormattingExtensions.cs
@@ -46,15 +46,23 @@ namespace NuGetMcpServer.Extensions
                 return name;
             }
 
-            var resultName = GetNestedName(type);
-
-            if (type.IsGenericType)
+            try
             {
-                var genericArgs = type.GetGenericArguments();
-                resultName += $"<{string.Join(", ", genericArgs.Select(FormatCSharpTypeName))}>";
-            }
+                var resultName = GetNestedName(type);
 
-            return resultName;
+                if (type.IsGenericType)
+                {
+                    var genericArgs = type.GetGenericArguments();
+                    resultName += $"<{string.Join(", ", genericArgs.Select(FormatCSharpTypeName))}>";
+                }
+
+                return resultName;
+            }
+            catch (Exception ex) when (ex is System.IO.FileNotFoundException || ex is TypeLoadException)
+            {
+                // Fall back to using the raw name when dependencies are missing
+                return (type.FullName ?? type.Name).FormatFullGenericTypeName();
+            }
         }
         public static string FormatGenericTypeName(this string typeName)
         {

--- a/NugetMcpServer/Tools/GetClassDefinitionTool.cs
+++ b/NugetMcpServer/Tools/GetClassDefinitionTool.cs
@@ -2,6 +2,7 @@ using System;
 using System.ComponentModel;
 using System.Linq;
 using System.Threading.Tasks;
+using System.IO;
 
 using Microsoft.Extensions.Logging;
 
@@ -124,6 +125,10 @@ public class GetClassDefinitionTool(
                     var formatted = formattingService.FormatClassDefinition(classType, assemblyInfo.FileName, packageId, assemblyInfo.AssemblyBytes);
                     return metaPackageWarning + formatted;
                 }
+            }
+            catch (FileNotFoundException)
+            {
+                // Missing referenced assembly - skip logging
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
## Summary
- handle missing dependencies in `FormatCSharpTypeName`
- stop logging `FileNotFoundException` while fetching class definitions

## Testing
- `dotnet test -v minimal --logger trx`

------
https://chatgpt.com/codex/tasks/task_e_688a187f498c832aba1bf93459c39d69