### PR TITLE
Improve class listing format

### DIFF
--- a/NugetMcpServer.Tests/Integration/PopularPackagesSmokeTests.cs
+++ b/NugetMcpServer.Tests/Integration/PopularPackagesSmokeTests.cs
@@ -90,38 +90,46 @@ public class PopularPackagesSmokeTests : TestBase
         TestOutput.WriteLine($"{packageId} v{version}: Classes={classCount}, Interfaces={interfaceCount}, Enums={enumCount}");
 
         var classResult = await listClassesTool.list_classes_and_records(packageId, version);
+        TestOutput.WriteLine("list_classes_and_records =>");
         TestOutput.WriteLine(classResult.Format());
         foreach (var cls in classResult.Classes)
         {
             var def = await classDefTool.get_class_or_record_definition(packageId, cls.FullName, version);
             Assert.False(string.IsNullOrWhiteSpace(def));
+            TestOutput.WriteLine($"get_class_or_record_definition({cls.FullName}) =>");
             TestOutput.WriteLine(def);
         }
 
         var interfaceResult = await listInterfacesTool.list_interfaces(packageId, version);
+        TestOutput.WriteLine("list_interfaces =>");
         TestOutput.WriteLine(interfaceResult.Format());
         foreach (var iface in interfaceResult.Interfaces)
         {
             var def = await interfaceDefTool.get_interface_definition(packageId, iface.FullName, version);
             Assert.False(string.IsNullOrWhiteSpace(def));
+            TestOutput.WriteLine($"get_interface_definition({iface.FullName}) =>");
             TestOutput.WriteLine(def);
         }
 
         var structResult = await listStructsTool.list_structs(packageId, version);
+        TestOutput.WriteLine("list_structs =>");
         TestOutput.WriteLine(structResult.Format());
         foreach (var st in structResult.Structs)
         {
             var def = await structDefTool.get_struct_definition(packageId, st.FullName, version);
             Assert.False(string.IsNullOrWhiteSpace(def));
+            TestOutput.WriteLine($"get_struct_definition({st.FullName}) =>");
             TestOutput.WriteLine(def);
         }
 
         var recordResult = await listRecordsTool.list_records(packageId, version);
+        TestOutput.WriteLine("list_records =>");
         TestOutput.WriteLine(recordResult.Format());
         foreach (var rec in recordResult.Records)
         {
             var def = await recordDefTool.get_record_definition(packageId, rec.FullName, version);
             Assert.False(string.IsNullOrWhiteSpace(def));
+            TestOutput.WriteLine($"get_record_definition({rec.FullName}) =>");
             TestOutput.WriteLine(def);
         }
 

--- a/NugetMcpServer.Tests/Services/PackageResultBaseTests.cs
+++ b/NugetMcpServer.Tests/Services/PackageResultBaseTests.cs
@@ -53,7 +53,6 @@ public class PackageResultBaseTests
 
         Assert.Contains("META-PACKAGE: SomeMetaPackage v1.0.0", formatted);
         Assert.Contains("SomePackage.Core", formatted);
-        Assert.Contains("This meta-package also contains the following classes", formatted);
         Assert.Contains("MetaClass", formatted);
         Assert.DoesNotContain("To see actual classes and interfaces, please analyze one of the dependency packages", formatted);
     }
@@ -71,7 +70,6 @@ public class PackageResultBaseTests
 
         var formatted = result.Format();
 
-        Assert.Contains("Classes from Newtonsoft.Json v13.0.3", formatted);
         Assert.Contains("No public classes found in this package", formatted);
         Assert.DoesNotContain("META-PACKAGE", formatted);
     }

--- a/NugetMcpServer/Services/ClassFormattingService.cs
+++ b/NugetMcpServer/Services/ClassFormattingService.cs
@@ -113,6 +113,12 @@ public class ClassFormattingService
 
         AddNestedDelegates(sb, classType);
 
+        if (sb.Length >= Environment.NewLine.Length &&
+            sb.ToString(sb.Length - Environment.NewLine.Length, Environment.NewLine.Length) == Environment.NewLine)
+        {
+            sb.Length -= Environment.NewLine.Length;
+        }
+
         sb.AppendLine("}");
         return sb.ToString();
     }


### PR DESCRIPTION
## Summary
- clarify output of `LoadPopularPackages_NoErrors` by naming MCP functions
- reformat `ClassListResultFormatter` to output C#-style lines
- trim extra blank line in class definitions
- update unit tests

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_688a2514d2a4832a9cc7430eec413d8a