### PR TITLE
Fix interface formatting for missing dependencies

### DIFF
--- a/NugetMcpServer/Services/TypeFormattingHelpers.cs
+++ b/NugetMcpServer/Services/TypeFormattingHelpers.cs
@@ -69,14 +69,44 @@ public static class TypeFormattingHelpers
     public static IEnumerable<PropertyInfo> GetRegularProperties(Type type)
     {
         var properties = type.GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static);
-        return properties.Where(p => p.GetIndexParameters().Length == 0);
+        foreach (var property in properties)
+        {
+            bool isIndexer;
+            try
+            {
+                isIndexer = property.GetIndexParameters().Length > 0;
+            }
+            catch (Exception ex) when (ex is System.IO.FileNotFoundException || ex is TypeLoadException)
+            {
+                // Skip property if index parameters can't be resolved
+                continue;
+            }
+
+            if (!isIndexer)
+                yield return property;
+        }
     }
 
     // Gets all indexer properties
     public static IEnumerable<PropertyInfo> GetIndexerProperties(Type type)
     {
         var properties = type.GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static);
-        return properties.Where(p => p.GetIndexParameters().Length > 0);
+        foreach (var property in properties)
+        {
+            bool isIndexer;
+            try
+            {
+                isIndexer = property.GetIndexParameters().Length > 0;
+            }
+            catch (Exception ex) when (ex is System.IO.FileNotFoundException || ex is TypeLoadException)
+            {
+                // Skip property if index parameters can't be resolved
+                continue;
+            }
+
+            if (isIndexer)
+                yield return property;
+        }
     }
 
     // Gets all public fields that are constants


### PR DESCRIPTION
## Summary
- handle missing dependencies in InterfaceFormattingService
- skip problematic properties and methods when dependencies are absent
- guard TypeFormattingHelpers when inspecting indexers

## Testing
- `dotnet test NugetMcpServer.sln --no-build -v minimal` *(fails: MSBUILD : error MSB4166)*

------
https://chatgpt.com/codex/tasks/task_e_688a4467399c832abf6ec83cf90b0c32