### PR TITLE
Remove unused method

### DIFF
--- a/NugetMcpServer.Tests/Services/NuGetPackageServiceTests.cs
+++ b/NugetMcpServer.Tests/Services/NuGetPackageServiceTests.cs
@@ -62,7 +62,7 @@ namespace NuGetMcpServer.Tests.Services
             stream.Position = 0;
 
             // Test loading from memory
-            var loadedAssembly = _packageService.LoadAssemblyFromMemory(stream.ToArray());
+            var (loadedAssembly, _) = _packageService.LoadAssemblyFromMemoryWithTypes(stream.ToArray());
 
             // Assert
             Assert.NotNull(loadedAssembly);

--- a/NugetMcpServer/Services/NuGetPackageService.cs
+++ b/NugetMcpServer/Services/NuGetPackageService.cs
@@ -98,21 +98,6 @@ public class NuGetPackageService(ILogger<NuGetPackageService> logger, HttpClient
     }
 
 
-    public Assembly? LoadAssemblyFromMemory(byte[] assemblyData, AssemblyLoadContext? loadContext = null)
-    {
-        try
-        {
-            return loadContext == null
-                ? Assembly.Load(assemblyData)
-                : loadContext.LoadFromStream(new MemoryStream(assemblyData));
-        }
-        catch (Exception ex)
-        {
-            logger.LogWarning(ex, "Failed to load assembly from memory. Assembly size: {Size} bytes", assemblyData.Length);
-            return null;
-        }
-    }
-
 
     public List<PackageDependency> GetPackageDependencies(Stream packageStream)
     {


### PR DESCRIPTION
## Summary
- drop unused `LoadAssemblyFromMemory` from NuGetPackageService
- adjust tests to use `LoadAssemblyFromMemoryWithTypes`

## Testing
- `dotnet build NugetMcpServer.sln -clp:ErrorsOnly`
- `dotnet test NugetMcpServer.sln --no-build --verbosity minimal` *(fails: build canceled)*

------
https://chatgpt.com/codex/tasks/task_e_688a8ad55c54832a8f9d990407fad44f