### PR TITLE
Remove duplicate tool tests

### DIFF
--- a/NugetMcpServer.Tests/Tools/GetClassDefinitionToolTests.cs
+++ b/NugetMcpServer.Tests/Tools/GetClassDefinitionToolTests.cs
@@ -63,36 +63,6 @@ public class GetClassDefinitionToolTests : TestBase
         TestOutput.WriteLine("======================================================\n");
     }
 
-    [Fact]
-    public async Task GetClassDefinition_WithPackageAndListTool_WorksWithBothTools()
-    {
-        // This test verifies that both tools can work together on the same package
-        var listToolLogger = new TestLogger<ListClassesTool>(TestOutput);
-        var archiveProcessingService = CreateArchiveProcessingService();
-        var listTool = new ListClassesTool(listToolLogger, _packageService, archiveProcessingService);
-
-        var packageId = "DimonSmart.MazeGenerator";
-
-        // Step 1: List classes in the package
-        var result = await listTool.list_classes_and_records(packageId);
-        Assert.NotNull(result);
-        Assert.NotEmpty(result.Classes);
-
-        // Step 2: Get definition of one of the classes
-        var mazeClass = result.Classes.FirstOrDefault(c => c.Name.StartsWith("Cell"));
-        if (mazeClass != null)
-        {
-            var definition = await _defTool.get_class_or_record_definition(packageId, mazeClass.Name, result.Version);
-
-            // Assert
-            Assert.Contains("class", definition);
-            Assert.Contains("Cell", definition);
-
-            TestOutput.WriteLine("\n========== TEST OUTPUT: RESULT OF GetClassDefinition ==========");
-            TestOutput.WriteLine(definition);
-            TestOutput.WriteLine("=============================================================\n");
-        }
-    }
 
     [Fact]
     public async Task GetClassDefinition_WithFullName_ReturnsDefinition()

--- a/NugetMcpServer.Tests/Tools/GetInterfaceDefinitionToolTests.cs
+++ b/NugetMcpServer.Tests/Tools/GetInterfaceDefinitionToolTests.cs
@@ -64,39 +64,6 @@ namespace NuGetMcpServer.Tests.Tools
             TestOutput.WriteLine("================================================================\n");
         }
 
-        [Fact]
-        public async Task GetInterfaceDefinition_WithPackageAndListTool_WorksWithBothTools()
-        {
-            // This test verifies that both tools can work together on the same package
-            var listToolLogger = new TestLogger<ListInterfacesTool>(TestOutput);
-            var archiveProcessingService = CreateArchiveProcessingService();
-            var listTool = new ListInterfacesTool(listToolLogger, _packageService, archiveProcessingService);
-
-            var packageId = "DimonSmart.MazeGenerator";
-
-            // Step 1: List interfaces in the package
-            var result = await listTool.list_interfaces(packageId);
-            Assert.NotNull(result);
-            Assert.NotEmpty(result.Interfaces);
-
-            // Step 2: Get definition of one of the interfaces
-            var mazeInterface = result.Interfaces.FirstOrDefault(i => i.Name.StartsWith("IMaze"));
-            if (mazeInterface != null)
-            {
-                var definition = await _defTool.get_interface_definition(
-                    packageId,
-                    mazeInterface.Name,
-                    result.Version);
-
-                // Assert
-                Assert.Contains("interface", definition);
-                Assert.Contains("IMaze<", definition);
-
-                TestOutput.WriteLine("\n========== TEST OUTPUT: RESULT OF GetInterfaceDefinition ==========");
-                TestOutput.WriteLine(definition);
-                TestOutput.WriteLine("================================================================\n");
-            }
-        }
 
         [Fact]
         public async Task GetInterfaceDefinition_WithFullName_ReturnsDefinition()


### PR DESCRIPTION
## Summary
- drop duplicate integration-style tests for class and interface tools

## Testing
- `dotnet test` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_688b181640b8832a8ff170b41a0b20d8