### PR TITLE
Add record and struct flags for class listing

### DIFF
--- a/NugetMcpServer.Tests/Integration/PopularPackagesSmokeTests.cs
+++ b/NugetMcpServer.Tests/Integration/PopularPackagesSmokeTests.cs
@@ -159,6 +159,22 @@ public class PopularPackagesSmokeTests : TestBase
             TestOutput.WriteLine(def);
         }
 
+        // Verify class flags against record and struct listings
+        var structNames = structResult.Structs.Select(s => s.FullName).ToHashSet();
+        var recordLookup = recordResult.Records.ToDictionary(r => r.FullName, r => r.IsStruct);
+
+        foreach (var cls in classResult.Classes)
+        {
+            if (cls.IsStruct)
+                Assert.Contains(cls.FullName, structNames);
+
+            if (cls.IsRecord)
+            {
+                Assert.True(recordLookup.TryGetValue(cls.FullName, out bool recIsStruct));
+                Assert.Equal(recIsStruct, cls.IsStruct);
+            }
+        }
+
         Assert.Empty(listClassesLogger.Entries.Where(e => e.Exception != null));
         Assert.Empty(classDefLogger.Entries.Where(e => e.Exception != null));
         Assert.Empty(listInterfacesLogger.Entries.Where(e => e.Exception != null));

--- a/NugetMcpServer.Tests/Tools/ListClassesToolTests.cs
+++ b/NugetMcpServer.Tests/Tools/ListClassesToolTests.cs
@@ -45,6 +45,9 @@ public class ListClassesToolTests : TestBase
 
         // Verify we found expected classes - using Point instead of Cell as Cell doesn't exist in current version
         Assert.Contains(result.Classes, c => c.Name == "Point" || c.FullName.Contains(".Point"));
+
+        // Ensure that structs and records are also included
+        Assert.Contains(result.Classes, c => c.IsStruct || c.IsRecord);
     }
 
     [Fact]

--- a/NugetMcpServer/Services/ClassInfo.cs
+++ b/NugetMcpServer/Services/ClassInfo.cs
@@ -8,4 +8,6 @@ public class ClassInfo
     public bool IsStatic { get; set; }
     public bool IsAbstract { get; set; }
     public bool IsSealed { get; set; }
+    public bool IsRecord { get; set; }
+    public bool IsStruct { get; set; }
 }

--- a/NugetMcpServer/Services/Formatters/ClassListResultFormatter.cs
+++ b/NugetMcpServer/Services/Formatters/ClassListResultFormatter.cs
@@ -43,7 +43,11 @@ public static class ClassListResultFormatter
                         : string.Empty;
             sb.Append(modifier);
 
-            sb.AppendLine($"class {formattedName}");
+            string typeKeyword = cls.IsRecord
+                ? (cls.IsStruct ? "record struct" : "record")
+                : (cls.IsStruct ? "struct" : "class");
+
+            sb.AppendLine($"{typeKeyword} {formattedName}");
         }
 
         return sb.ToString();

--- a/NugetMcpServer/Tools/ListClassesTool.cs
+++ b/NugetMcpServer/Tools/ListClassesTool.cs
@@ -59,7 +59,9 @@ public class ListClassesTool(ILogger<ListClassesTool> logger, NuGetPackageServic
         foreach (LoadedAssemblyInfo assemblyInfo in loaded.Assemblies)
         {
             System.Collections.Generic.List<Type> classes = assemblyInfo.Types
-                .Where(t => t.IsClass && (t.IsPublic || t.IsNestedPublic))
+                .Where(t =>
+                    (t.IsClass || TypeFormattingHelpers.IsRecordType(t) || (t.IsValueType && !t.IsEnum)) &&
+                    (t.IsPublic || t.IsNestedPublic))
                 .ToList();
 
             foreach (Type? cls in classes)
@@ -71,7 +73,9 @@ public class ListClassesTool(ILogger<ListClassesTool> logger, NuGetPackageServic
                     AssemblyName = assemblyInfo.FileName,
                     IsStatic = cls.IsAbstract && cls.IsSealed,
                     IsAbstract = cls.IsAbstract && !cls.IsSealed,
-                    IsSealed = cls.IsSealed && !cls.IsAbstract
+                    IsSealed = cls.IsSealed && !cls.IsAbstract,
+                    IsRecord = TypeFormattingHelpers.IsRecordType(cls),
+                    IsStruct = cls.IsValueType && !cls.IsEnum
                 });
             }
         }


### PR DESCRIPTION
## Summary
- mark records and structs in `ClassInfo`
- include structs and records in class listing logic
- improve class list output to show type keywords
- test that structs/records appear in class listing
- validate class flags in integration tests

## Testing
- `dotnet test NugetMcpServer.sln --no-build --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_688b66d6574c832a967cfb05fa25dea6