### PR TITLE
Rename fuzzy search packages method

### DIFF
--- a/NugetMcpServer.Tests/Tools/SearchPackagesFuzzyToolTests.cs
+++ b/NugetMcpServer.Tests/Tools/SearchPackagesFuzzyToolTests.cs
@@ -6,14 +6,14 @@ using Xunit.Abstractions;
 
 namespace NuGetMcpServer.Tests.Tools;
 
-public class FuzzySearchPackagesToolTests : TestBase
+public class SearchPackagesFuzzyToolTests : TestBase
 {
     private readonly TestLogger<NuGetPackageService> _packageLogger;
     private readonly TestLogger<FuzzySearchPackagesTool> _toolLogger;
     private readonly NuGetPackageService _packageService;
     private readonly FuzzySearchPackagesTool _tool;
 
-    public FuzzySearchPackagesToolTests(ITestOutputHelper testOutput) : base(testOutput)
+    public SearchPackagesFuzzyToolTests(ITestOutputHelper testOutput) : base(testOutput)
     {
         _packageLogger = new TestLogger<NuGetPackageService>(TestOutput);
         _toolLogger = new TestLogger<FuzzySearchPackagesTool>(TestOutput);
@@ -26,15 +26,15 @@ public class FuzzySearchPackagesToolTests : TestBase
     [Theory]
     [InlineData("")]
     [InlineData("   ")]
-    public async Task FuzzySearchPackages_InvalidQuery_ThrowsArgumentException(string query)
+    public async Task SearchPackagesFuzzy_InvalidQuery_ThrowsArgumentException(string query)
     {
         // Act & Assert
         await Assert.ThrowsAsync<ArgumentException>(() =>
-            _tool.fuzzy_search_packages(null!, query));
+            _tool.search_packages_fuzzy(null!, query));
     }
 
     [Fact]
-    public async Task FuzzySearchPackages_WithMaxResultsExceedsLimit_ClampsResults()
+    public async Task SearchPackagesFuzzy_WithMaxResultsExceedsLimit_ClampsResults()
     {
         // Arrange
         const string query = "logging";
@@ -43,11 +43,11 @@ public class FuzzySearchPackagesToolTests : TestBase
         // We expect this to fail because we don't have a real server
         // but the validation should still work
         await Assert.ThrowsAsync<ArgumentNullException>(() =>
-            _tool.fuzzy_search_packages(null!, query, maxResults));
+            _tool.search_packages_fuzzy(null!, query, maxResults));
     }
 
     [Fact]
-    public async Task FuzzySearchPackages_WithCancellation_PropagatesCancellation()
+    public async Task SearchPackagesFuzzy_WithCancellation_PropagatesCancellation()
     {
         // Arrange
         const string query = "test";
@@ -56,6 +56,6 @@ public class FuzzySearchPackagesToolTests : TestBase
 
         // Act & Assert
         await Assert.ThrowsAsync<OperationCanceledException>(() =>
-            _tool.fuzzy_search_packages(null!, query, cancellationToken: cts.Token));
+            _tool.search_packages_fuzzy(null!, query, cancellationToken: cts.Token));
     }
 }

--- a/NugetMcpServer/Tools/FuzzySearchPackagesTool.cs
+++ b/NugetMcpServer/Tools/FuzzySearchPackagesTool.cs
@@ -21,7 +21,7 @@ public class FuzzySearchPackagesTool(ILogger<FuzzySearchPackagesTool> logger, Pa
 {
     [McpServerTool]
     [Description("Advanced fuzzy search for NuGet packages using AI-generated alternatives and word matching. Use this method when regular search doesn't return desired results. This method uses sampling and may provide broader but less precise results.")]
-    public Task<PackageSearchResult> fuzzy_search_packages(
+    public Task<PackageSearchResult> search_packages_fuzzy(
         IMcpServer thisServer,
         [Description("Description of the functionality you're looking for")] string query,
         [Description("Maximum number of results to return (default: 20, max: 100)")] int maxResults = 20,


### PR DESCRIPTION
## Summary
- rename `fuzzy_search_packages` to `search_packages_fuzzy`
- update tests referencing the fuzzy search method

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_688b8d9feba8832a8ee56b16a366dd75