### PR TITLE
Simplify MetaPackage warning API

### DIFF
--- a/NugetMcpServer/Common/MetaPackageHelper.cs
+++ b/NugetMcpServer/Common/MetaPackageHelper.cs
@@ -6,13 +6,13 @@ namespace NuGetMcpServer.Common;
 
 public static class MetaPackageHelper
 {
-    public static string CreateMetaPackageWarning(PackageInfo packageInfo, string packageId, string version)
+    public static string CreateMetaPackageWarning(PackageInfo packageInfo)
     {
         if (!packageInfo.IsMetaPackage)
             return string.Empty;
 
         var warning = new StringBuilder();
-        warning.AppendLine($"⚠️  META-PACKAGE: {packageId} v{version}");
+        warning.AppendLine($"⚠️  META-PACKAGE: {packageInfo.PackageId} v{packageInfo.Version}");
         warning.AppendLine("This package groups other related packages together and may not contain actual implementation code.");
 
         if (packageInfo.Dependencies.Count > 0)

--- a/NugetMcpServer/Tools/GetClassDefinitionTool.cs
+++ b/NugetMcpServer/Tools/GetClassDefinitionTool.cs
@@ -60,7 +60,7 @@ public class GetClassDefinitionTool(
             "Fetching class, record or struct {ClassName} from package {PackageId} version {Version}",
             typeName, packageId, resolvedVersion);
 
-        string metaPackageWarning = MetaPackageHelper.CreateMetaPackageWarning(packageInfo, packageId, resolvedVersion);
+        string metaPackageWarning = MetaPackageHelper.CreateMetaPackageWarning(packageInfo);
 
         progress.ReportMessage("Scanning assemblies for class/record/struct");
 

--- a/NugetMcpServer/Tools/GetEnumDefinitionTool.cs
+++ b/NugetMcpServer/Tools/GetEnumDefinitionTool.cs
@@ -58,7 +58,7 @@ public class GetEnumDefinitionTool(
             "Fetching enum {EnumName} from package {PackageId} version {Version}",
             enumName, packageId, resolvedVersion);
 
-        string metaPackageWarning = MetaPackageHelper.CreateMetaPackageWarning(packageInfo, packageId, resolvedVersion);
+        string metaPackageWarning = MetaPackageHelper.CreateMetaPackageWarning(packageInfo);
 
         progress.ReportMessage("Scanning assemblies for enum");
 

--- a/NugetMcpServer/Tools/GetInterfaceDefinitionTool.cs
+++ b/NugetMcpServer/Tools/GetInterfaceDefinitionTool.cs
@@ -61,7 +61,7 @@ public class GetInterfaceDefinitionTool(
             "Fetching interface {InterfaceName} from package {PackageId} version {Version}",
             interfaceName, packageId, resolvedVersion);
 
-        var metaPackageWarning = MetaPackageHelper.CreateMetaPackageWarning(packageInfo, packageId, resolvedVersion);
+        var metaPackageWarning = MetaPackageHelper.CreateMetaPackageWarning(packageInfo);
 
         foreach (var assemblyInfo in loaded.Assemblies)
         {


### PR DESCRIPTION
## Summary
- remove duplicated parameters from `MetaPackageHelper.CreateMetaPackageWarning`
- adjust tools to use the new helper signature

## Testing
- `dotnet test --verbosity minimal`
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_688cb7cb9914832ab2b5c6b1c9de4fb2