### PR TITLE
Add file access tools for NuGet packages

### DIFF
--- a/NugetMcpServer.Tests/Tools/PackageFileToolTests.cs
+++ b/NugetMcpServer.Tests/Tools/PackageFileToolTests.cs
@@ -1,0 +1,50 @@
+using System;
+using NuGetMcpServer.Services;
+using NuGetMcpServer.Tests.Helpers;
+using NuGetMcpServer.Tools;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace NuGetMcpServer.Tests.Tools;
+
+public class PackageFileToolTests : TestBase
+{
+    private readonly TestLogger<NuGetPackageService> _packageLogger;
+    private readonly TestLogger<PackageFileTool> _toolLogger;
+    private readonly NuGetPackageService _packageService;
+    private readonly PackageFileTool _tool;
+
+    public PackageFileToolTests(ITestOutputHelper testOutput) : base(testOutput)
+    {
+        _packageLogger = new TestLogger<NuGetPackageService>(TestOutput);
+        _toolLogger = new TestLogger<PackageFileTool>(TestOutput);
+        _packageService = CreateNuGetPackageService();
+        _tool = new PackageFileTool(_toolLogger, _packageService);
+    }
+
+    [Fact]
+    public async Task ListPackageFiles_ReturnsFiles()
+    {
+        var result = await _tool.list_package_files("Newtonsoft.Json", "13.0.3");
+        Assert.NotEmpty(result.Files);
+        Assert.Contains(result.Files, f => f.EndsWith("LICENSE.md"));
+    }
+
+    [Fact]
+    public async Task GetPackageFile_TextFile_ReturnsContent()
+    {
+        var result = await _tool.get_package_file("Newtonsoft.Json", "LICENSE.md", "13.0.3", bytes: 100);
+        Assert.False(result.IsBinary);
+        Assert.Contains("MIT", result.Content);
+    }
+
+    [Fact]
+    public async Task GetPackageFile_BinaryFile_ReturnsBase64()
+    {
+        var result = await _tool.get_package_file("Newtonsoft.Json", "lib/net45/Newtonsoft.Json.dll", "13.0.3", bytes: 10);
+        Assert.True(result.IsBinary);
+        var data = Convert.FromBase64String(result.Content);
+        Assert.Equal(10, data.Length);
+    }
+}
+

--- a/NugetMcpServer/Services/FileContentResult.cs
+++ b/NugetMcpServer/Services/FileContentResult.cs
@@ -1,0 +1,9 @@
+namespace NuGetMcpServer.Services;
+
+public class FileContentResult : PackageResultBase
+{
+    public string FilePath { get; set; } = string.Empty;
+    public string Content { get; set; } = string.Empty;
+    public bool IsBinary { get; set; }
+}
+

--- a/NugetMcpServer/Services/FileListResult.cs
+++ b/NugetMcpServer/Services/FileListResult.cs
@@ -1,0 +1,9 @@
+using System.Collections.Generic;
+
+namespace NuGetMcpServer.Services;
+
+public class FileListResult : PackageResultBase
+{
+    public List<string> Files { get; set; } = [];
+}
+

--- a/NugetMcpServer/Tools/PackageFileTool.cs
+++ b/NugetMcpServer/Tools/PackageFileTool.cs
@@ -1,0 +1,85 @@
+using System;
+using System.ComponentModel;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using ModelContextProtocol;
+using ModelContextProtocol.Server;
+using NuGetMcpServer.Common;
+using NuGetMcpServer.Extensions;
+using NuGetMcpServer.Services;
+using static NuGetMcpServer.Extensions.ExceptionHandlingExtensions;
+
+namespace NuGetMcpServer.Tools;
+
+[McpServerToolType]
+public class PackageFileTool(ILogger<PackageFileTool> logger, NuGetPackageService packageService) : McpToolBase<PackageFileTool>(logger, packageService)
+{
+    [McpServerTool]
+    [Description("Lists all files inside a NuGet package.")]
+    public Task<FileListResult> list_package_files(
+        [Description("NuGet package ID")] string packageId,
+        [Description("Package version (optional, defaults to latest)")] string? version = null,
+        [Description("Progress notification for long-running operations")] IProgress<ProgressNotificationValue>? progress = null)
+    {
+        using var progressNotifier = new ProgressNotifier(progress);
+        return ExecuteWithLoggingAsync(
+            () => ListFilesCore(packageId, version, progressNotifier),
+            Logger,
+            "Error listing package files");
+    }
+
+    [McpServerTool]
+    [Description("Reads a file from a NuGet package. Returns text or base64 for binary files. Supports optional offset and byte count. Max chunk size: 1 MB.")]
+    public Task<FileContentResult> get_package_file(
+        [Description("NuGet package ID")] string packageId,
+        [Description("File path inside the package")] string filePath,
+        [Description("Package version (optional, defaults to latest)")] string? version = null,
+        [Description("Byte offset within the file (optional)")] long offset = 0,
+        [Description("Maximum number of bytes to read (optional, max: 1048576)")] int? bytes = null,
+        [Description("Progress notification for long-running operations")] IProgress<ProgressNotificationValue>? progress = null)
+    {
+        using var progressNotifier = new ProgressNotifier(progress);
+        return ExecuteWithLoggingAsync(
+            () => GetFileCore(packageId, filePath, version, offset, bytes, progressNotifier),
+            Logger,
+            "Error reading package file");
+    }
+
+    private async Task<FileListResult> ListFilesCore(string packageId, string? version, IProgressNotifier progress)
+    {
+        if (string.IsNullOrWhiteSpace(packageId))
+            throw new ArgumentNullException(nameof(packageId));
+
+        progress.ReportMessage("Resolving package version");
+        if (version.IsNullOrEmptyOrNullString())
+            version = await PackageService.GetLatestVersion(packageId);
+
+        progress.ReportMessage($"Downloading package {packageId} v{version}");
+        var files = await PackageService.ListPackageFilesAsync(packageId, version!, progress);
+
+        return new FileListResult
+        {
+            PackageId = packageId,
+            Version = version!,
+            Files = files.ToList()
+        };
+    }
+
+    private async Task<FileContentResult> GetFileCore(string packageId, string filePath, string? version, long offset, int? bytes, IProgressNotifier progress)
+    {
+        if (string.IsNullOrWhiteSpace(packageId))
+            throw new ArgumentNullException(nameof(packageId));
+        if (string.IsNullOrWhiteSpace(filePath))
+            throw new ArgumentNullException(nameof(filePath));
+
+        progress.ReportMessage("Resolving package version");
+        if (version.IsNullOrEmptyOrNullString())
+            version = await PackageService.GetLatestVersion(packageId);
+
+        progress.ReportMessage($"Downloading package {packageId} v{version}");
+        var result = await PackageService.GetPackageFileAsync(packageId, version!, filePath, offset, bytes, progress);
+        return result;
+    }
+}
+

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ You can use this server with [OllamaChat](https://github.com/DimonSmart/OllamaCh
 - Reduces LLM hallucinations by giving accurate API information
 - Supports specific package versions or latest version
 - Supports generic types with correct C# formatting
+- Can list and read arbitrary files from NuGet packages
 - Uses STDIO for client communication
 - Includes a time utility tool for basic server checks
 - Built with .NET 9.0 for good performance
@@ -112,6 +113,11 @@ The server uses the .NET Generic Host and includes:
 
 - `get_class_or_record_or_struct_definition(packageId, typeName, version?)` - Gets the C# class, record or struct definition from a NuGet package. Parameters: packageId (NuGet package ID), typeName (short or full name), version (optional, defaults to latest)
  - `list_classes_records_structs(packageId, version?)` - Lists all public classes, records and structs in a NuGet package. Returns package ID, version, and the list of types
+
+### Package File Tools
+
+- `list_package_files(packageId, version?)` - Lists all files in a NuGet package.
+- `get_package_file(packageId, filePath, version?, offset?, bytes?)` - Reads a file from a NuGet package. Returns text or base64 for binary files. Maximum chunk size is 1 MB.
 
 ### Package Search Tools
 


### PR DESCRIPTION
## Summary
- add service methods to list files and fetch package file chunks
- expose new `list_package_files` and `get_package_file` tools
- document file access feature and chunk limits

## Testing
- `dotnet format -v d`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a73f9c65dc832a90bcf76aa28d84ee