### PR TITLE
  feat: add compare_package_versions tool with breaking change detection

### DIFF
--- a/NugetMcpServer.Tests/Tools/ComparePackageVersionsToolTests.cs
+++ b/NugetMcpServer.Tests/Tools/ComparePackageVersionsToolTests.cs
@@ -1,0 +1,963 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Loader;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using NuGetMcpServer.Models;
+using NuGetMcpServer.Services;
+using NuGetMcpServer.Tools;
+using Xunit;
+
+namespace NuGetMcpServer.Tests.Tools;
+
+public class ComparePackageVersionsToolTests
+{
+    [Fact]
+    public void ChangeCategory_ShouldHaveAllExpectedValues()
+    {
+        // Verify the enum has all expected categories
+        var categories = Enum.GetValues<ChangeCategory>();
+
+        Assert.Contains(ChangeCategory.TypeRemoved, categories);
+        Assert.Contains(ChangeCategory.TypeAdded, categories);
+        Assert.Contains(ChangeCategory.MemberRemoved, categories);
+        Assert.Contains(ChangeCategory.MemberAdded, categories);
+        Assert.Contains(ChangeCategory.EnumValueRemoved, categories);
+    }
+
+    [Fact]
+    public void ChangeSeverity_ShouldHaveThreeLevels()
+    {
+        var severities = Enum.GetValues<ChangeSeverity>();
+
+        Assert.Equal(3, severities.Length);
+        Assert.Contains(ChangeSeverity.Low, severities);
+        Assert.Contains(ChangeSeverity.Medium, severities);
+        Assert.Contains(ChangeSeverity.High, severities);
+    }
+
+    [Fact]
+    public void TypeChange_ShouldStoreAllProperties()
+    {
+        // Arrange & Act
+        var change = new TypeChange
+        {
+            Category = ChangeCategory.MemberAdded,
+            Severity = ChangeSeverity.Low,
+            TypeName = "TestType",
+            TypeFullName = "Namespace.TestType",
+            MemberName = "NewMethod",
+            From = "old",
+            To = "new",
+            Documentation = "Test docs",
+            Impact = "Test impact",
+            Migration = "Test migration"
+        };
+
+        // Assert
+        Assert.Equal(ChangeCategory.MemberAdded, change.Category);
+        Assert.Equal(ChangeSeverity.Low, change.Severity);
+        Assert.Equal("TestType", change.TypeName);
+        Assert.Equal("Namespace.TestType", change.TypeFullName);
+        Assert.Equal("NewMethod", change.MemberName);
+        Assert.Equal("old", change.From);
+        Assert.Equal("new", change.To);
+        Assert.Equal("Test docs", change.Documentation);
+        Assert.Equal("Test impact", change.Impact);
+        Assert.Equal("Test migration", change.Migration);
+    }
+
+    [Fact]
+    public void ComparisonResult_ShouldInitializeWithDefaults()
+    {
+        // Arrange & Act
+        var result = new ComparisonResult();
+
+        // Assert
+        Assert.NotNull(result.Changes);
+        Assert.Empty(result.Changes);
+        Assert.NotNull(result.Summary);
+        Assert.False(result.IsTruncated);
+    }
+
+    // Integration tests with TestLibrary.V1 and V2
+
+    [Fact]
+    public async Task Compare_DetectsBreakingChange_TypeRemoved()
+    {
+        // ClassToRemove exists in V1 but not V2
+        var result = await CompareTestLibrariesAsync();
+
+        Assert.Contains(result.Changes, c =>
+            c.Category == ChangeCategory.TypeRemoved &&
+            c.TypeName == "ClassToRemove");
+    }
+
+    [Fact]
+    public async Task Compare_DetectsBreakingChange_MemberTypeChanged()
+    {
+        // ClassWithMemberTypeChange.Amount: int → long
+        var result = await CompareTestLibrariesAsync();
+
+        var change = result.Changes.FirstOrDefault(c =>
+            c.TypeName == "ClassWithMemberTypeChange" &&
+            c.MemberName == "Amount");
+
+        Assert.NotNull(change);
+        Assert.True(
+            change.Category == ChangeCategory.MemberRemoved ||
+            change.FromType == "Int32" ||
+            change.ToType == "Int64",
+            "Expected property type change from Int32 to Int64");
+    }
+
+    [Fact]
+    public async Task Compare_DetectsBreakingChange_MemberRemoved()
+    {
+        var result = await CompareTestLibrariesAsync();
+
+        Assert.Contains(result.Changes, c =>
+            c.Category == ChangeCategory.MemberRemoved &&
+            c.TypeName == "ClassWithMemberRemoval" &&
+            c.MemberName == "MethodToRemove");
+
+        Assert.Contains(result.Changes, c =>
+            c.Category == ChangeCategory.MemberRemoved &&
+            c.TypeName == "ClassWithMemberRemoval" &&
+            c.MemberName == "PropertyToRemove");
+
+        Assert.Contains(result.Changes, c =>
+            c.Category == ChangeCategory.MemberRemoved &&
+            c.TypeName == "ClassWithMemberRemoval" &&
+            c.MemberName == "FieldToRemove");
+    }
+
+    [Fact]
+    public async Task Compare_DetectsBreakingChange_MethodSignatureChanged()
+    {
+        var result = await CompareTestLibrariesAsync();
+
+        // MethodWithParamRemoval lost a parameter
+        Assert.Contains(result.Changes, c =>
+            c.TypeName == "ClassWithMethodSignatureChange" &&
+            c.MemberName == "MethodWithParamRemoval");
+
+        // MethodWithParamTypeChange: int → long parameter
+        Assert.Contains(result.Changes, c =>
+            c.TypeName == "ClassWithMethodSignatureChange" &&
+            c.MemberName == "MethodWithParamTypeChange");
+
+        // MethodWithReturnTypeChange: int → long return type
+        Assert.Contains(result.Changes, c =>
+            c.TypeName == "ClassWithMethodSignatureChange" &&
+            c.MemberName == "MethodWithReturnTypeChange" &&
+            c.Category == ChangeCategory.ReturnTypeChanged);
+    }
+
+    [Fact]
+    public async Task Compare_DetectsBreakingChange_VirtualRemoved()
+    {
+        var result = await CompareTestLibrariesAsync();
+
+        Assert.Contains(result.Changes, c =>
+            c.Category == ChangeCategory.VirtualRemoved &&
+            c.TypeName == "ClassWithVirtualRemoval" &&
+            c.MemberName == "VirtualMethod");
+    }
+
+    [Fact]
+    public async Task Compare_DetectsBreakingChange_BaseClassChanged()
+    {
+        var result = await CompareTestLibrariesAsync();
+
+        Assert.Contains(result.Changes, c =>
+            c.Category == ChangeCategory.BaseClassChanged &&
+            c.TypeName == "ClassWithBaseChange");
+    }
+
+    [Fact]
+    public async Task Compare_DetectsBreakingChange_InterfaceRemoved()
+    {
+        var result = await CompareTestLibrariesAsync();
+
+        Assert.Contains(result.Changes, c =>
+            c.Category == ChangeCategory.InterfaceRemoved &&
+            c.TypeName == "ClassWithInterfaceRemoval" &&
+            c.From != null && c.From.Contains("IInterface2"));
+    }
+
+    [Fact]
+    public async Task Compare_DetectsBreakingChange_AccessibilityReduced()
+    {
+        var result = await CompareTestLibrariesAsync();
+
+        // Accessibility changes are detected for methods only
+        // The method should be detected as MemberRemoved (public version) and possibly MemberAdded (internal version if it were still visible)
+        // Since internal members aren't public, we should see it as removed
+        Assert.Contains(result.Changes, c =>
+            c.Category == ChangeCategory.MemberRemoved &&
+            c.TypeName == "ClassWithAccessibilityReduction" &&
+            c.MemberName == "PublicMethod");
+    }
+
+    [Fact]
+    public async Task Compare_DetectsBreakingChange_SealedAdded()
+    {
+        var result = await CompareTestLibrariesAsync();
+
+        Assert.Contains(result.Changes, c =>
+            c.Category == ChangeCategory.SealedAdded &&
+            c.TypeName == "ClassToBeSealed");
+    }
+
+    [Fact]
+    public async Task Compare_DetectsBreakingChange_AbstractAdded()
+    {
+        var result = await CompareTestLibrariesAsync();
+
+        Assert.Contains(result.Changes, c =>
+            c.Category == ChangeCategory.AbstractAdded &&
+            c.TypeName == "ClassToBeAbstract");
+    }
+
+    [Fact]
+    public async Task Compare_DetectsBreakingChange_GenericParametersChanged()
+    {
+        var result = await CompareTestLibrariesAsync();
+
+        // GenericClass<T> in V1 becomes GenericClass<T, U> in V2
+        // This is detected as the old type being removed and a new type being added
+        // because they have different generic parameter counts
+        Assert.Contains(result.Changes, c =>
+            c.Category == ChangeCategory.TypeRemoved &&
+            c.TypeName.StartsWith("GenericClass"));
+
+        Assert.Contains(result.Changes, c =>
+            c.Category == ChangeCategory.TypeAdded &&
+            c.TypeName.StartsWith("GenericClass"));
+    }
+
+    [Fact]
+    public async Task Compare_DetectsBreakingChange_EnumValueRemoved()
+    {
+        var result = await CompareTestLibrariesAsync();
+
+        Assert.Contains(result.Changes, c =>
+            c.Category == ChangeCategory.EnumValueRemoved &&
+            c.TypeName == "EnumWithValueRemoval" &&
+            c.MemberName == "Value2");
+    }
+
+    [Fact]
+    public async Task Compare_DetectsNonBreaking_MemberObsoleted()
+    {
+        var result = await CompareTestLibrariesAsync();
+
+        Assert.Contains(result.Changes, c =>
+            c.Category == ChangeCategory.MemberObsoleted &&
+            c.TypeName == "ClassWithObsolete" &&
+            c.MemberName == "MethodToObsolete");
+    }
+
+    [Fact]
+    public async Task Compare_DetectsNonBreaking_AccessibilityExpanded()
+    {
+        var result = await CompareTestLibrariesAsync();
+
+        // Internal to public: the internal method wasn't visible before, so it appears as MemberAdded
+        Assert.Contains(result.Changes, c =>
+            c.Category == ChangeCategory.MemberAdded &&
+            c.TypeName == "ClassWithAccessibilityExpansion" &&
+            c.MemberName == "InternalMethod");
+    }
+
+    [Fact]
+    public async Task Compare_DetectsAddition_TypeAdded()
+    {
+        var result = await CompareTestLibrariesAsync();
+
+        Assert.Contains(result.Changes, c =>
+            c.Category == ChangeCategory.TypeAdded &&
+            c.TypeName == "NewClass");
+
+        Assert.Contains(result.Changes, c =>
+            c.Category == ChangeCategory.TypeAdded &&
+            c.TypeName == "IAddedInterface");
+
+        Assert.Contains(result.Changes, c =>
+            c.Category == ChangeCategory.TypeAdded &&
+            c.TypeName == "NewEnum");
+    }
+
+    [Fact]
+    public async Task Compare_DetectsAddition_MemberAdded()
+    {
+        var result = await CompareTestLibrariesAsync();
+
+        Assert.Contains(result.Changes, c =>
+            c.Category == ChangeCategory.MemberAdded &&
+            c.TypeName == "ClassWithAdditions" &&
+            c.MemberName == "NewMethod");
+
+        Assert.Contains(result.Changes, c =>
+            c.Category == ChangeCategory.MemberAdded &&
+            c.TypeName == "ClassWithAdditions" &&
+            c.MemberName == "NewProperty");
+
+        Assert.Contains(result.Changes, c =>
+            c.Category == ChangeCategory.MemberAdded &&
+            c.TypeName == "ClassWithAdditions" &&
+            c.MemberName == "NewField");
+    }
+
+    [Fact]
+    public async Task Compare_DetectsAddition_InterfaceAdded()
+    {
+        var result = await CompareTestLibrariesAsync();
+
+        Assert.Contains(result.Changes, c =>
+            c.Category == ChangeCategory.InterfaceAdded &&
+            c.TypeName == "ClassWithInterfaceAddition");
+    }
+
+    [Fact]
+    public async Task Compare_DetectsAddition_EnumValueAdded()
+    {
+        var result = await CompareTestLibrariesAsync();
+
+        Assert.Contains(result.Changes, c =>
+            c.Category == ChangeCategory.EnumValueAdded &&
+            c.TypeName == "EnumWithValueAddition" &&
+            c.MemberName == "Value3");
+    }
+
+    [Fact]
+    public async Task Compare_WithFilter_ReturnsOnlyMatchingTypes()
+    {
+        var result = await CompareTestLibrariesAsync(typeFilter: "*WithAdditions");
+
+        // All changes should be for ClassWithAdditions
+        Assert.All(result.Changes, c =>
+            Assert.Contains("WithAdditions", c.TypeName));
+    }
+
+    [Fact]
+    public async Task Compare_WithMaxChanges_TruncatesResults()
+    {
+        var result = await CompareTestLibrariesAsync(maxChangesPerCategory: 2);
+
+        Assert.True(result.IsTruncated);
+
+        // Should have at most 2 changes per category
+        var countsByCategory = result.Changes
+            .GroupBy(c => c.Category)
+            .ToDictionary(g => g.Key, g => g.Count());
+
+        Assert.All(countsByCategory.Values, count =>
+            Assert.True(count <= 2, $"Expected at most 2 changes per category, got {count}"));
+    }
+
+    [Fact]
+    public async Task Compare_Summary_CountsChangesCorrectly()
+    {
+        var result = await CompareTestLibrariesAsync();
+
+        Assert.True(result.Summary.TotalChanges > 0);
+        Assert.True(result.Summary.BreakingChanges > 0);
+        Assert.True(result.Summary.Additions > 0);
+        Assert.True(result.Summary.Removals > 0);
+
+        // Verify that all changes are accounted for
+        var sum = result.Summary.BreakingChanges +
+                  result.Summary.NonBreakingChanges +
+                  result.Summary.Additions;
+
+        // Note: Some changes may be counted in multiple categories
+        Assert.True(sum >= result.Summary.TotalChanges / 2);
+    }
+
+    [Fact]
+    public async Task Compare_WithBreakingChangesOnly_ExcludesAdditions()
+    {
+        // Compare with breakingChangesOnly flag
+        var result = await CompareTestLibrariesAsync(breakingChangesOnly: true);
+
+        // Should have breaking changes
+        Assert.True(result.Changes.Count > 0);
+        Assert.True(result.BreakingChangesOnly);
+
+        // All changes should be high severity
+        Assert.All(result.Changes, c => Assert.Equal(ChangeSeverity.High, c.Severity));
+
+        // Should NOT contain any additions (which are low severity)
+        Assert.DoesNotContain(result.Changes, c => c.Category == ChangeCategory.TypeAdded);
+        Assert.DoesNotContain(result.Changes, c => c.Category == ChangeCategory.MemberAdded);
+        Assert.DoesNotContain(result.Changes, c => c.Category == ChangeCategory.EnumValueAdded);
+    }
+
+    [Fact]
+    public async Task Compare_WithBreakingChangesOnly_SummaryShowsAll()
+    {
+        // Compare with breakingChangesOnly flag
+        var result = await CompareTestLibrariesAsync(breakingChangesOnly: true);
+
+        // Summary should show the full picture (before filtering)
+        Assert.True(result.Summary.TotalChanges > result.Changes.Count,
+            "Summary should include all changes, not just breaking ones");
+
+        // Summary should have additions even though they're not in Changes
+        Assert.True(result.Summary.Additions > 0,
+            "Summary should show additions even when breakingChangesOnly is true");
+
+        // Changes should only contain breaking
+        Assert.All(result.Changes, c => Assert.Equal(ChangeSeverity.High, c.Severity));
+    }
+
+    [Fact]
+    public async Task Compare_WithBreakingChangesOnlyAndFilter_BothApplied()
+    {
+        // Compare with both typeFilter and breakingChangesOnly
+        var result = await CompareTestLibrariesAsync(
+            typeFilter: "*WithAdditions",
+            breakingChangesOnly: true);
+
+        Assert.True(result.BreakingChangesOnly);
+        Assert.Equal("*WithAdditions", result.TypeNameFilter);
+
+        // All changes should be from *WithAdditions types
+        Assert.All(result.Changes, c => Assert.Contains("WithAdditions", c.TypeName));
+
+        // All changes should be high severity
+        Assert.All(result.Changes, c => Assert.Equal(ChangeSeverity.High, c.Severity));
+    }
+
+    [Fact]
+    public async Task Compare_WithMemberFilter_ReturnsOnlyMatchingMembers()
+    {
+        // Test exact match for "StarCount" member
+        var result = await CompareTestLibrariesAsync(memberFilter: "StarCount");
+
+        // Should have changes for StarCount member only
+        Assert.True(result.Changes.Count > 0, "Should have at least one StarCount change");
+        Assert.Equal("StarCount", result.MemberNameFilter);
+
+        // All changes should be for StarCount member
+        Assert.All(result.Changes, c => Assert.Equal("StarCount", c.MemberName));
+
+        // Should find StarCount in ClassForMemberFilter (int → long)
+        Assert.Contains(result.Changes, c =>
+            c.TypeName == "ClassForMemberFilter" &&
+            c.MemberName == "StarCount");
+
+        // Should also find StarCount in AnotherClassWithMembers (int → long)
+        Assert.Contains(result.Changes, c =>
+            c.TypeName == "AnotherClassWithMembers" &&
+            c.MemberName == "StarCount");
+    }
+
+    [Fact]
+    public async Task Compare_WithMemberFilterWildcard_MatchesPattern()
+    {
+        // Test wildcard pattern "*Id" to match all members ending with "Id"
+        var result = await CompareTestLibrariesAsync(memberFilter: "*Id");
+
+        Assert.True(result.Changes.Count > 0, "Should have changes for *Id members");
+        Assert.Equal("*Id", result.MemberNameFilter);
+
+        // All changes should be for members ending with "Id"
+        Assert.All(result.Changes, c =>
+        {
+            Assert.NotNull(c.MemberName);
+            Assert.EndsWith("Id", c.MemberName);
+        });
+
+        // Should find TopicId (int → string)
+        Assert.Contains(result.Changes, c =>
+            c.TypeName == "ClassForMemberFilter" &&
+            c.MemberName == "TopicId");
+
+        // Should NOT contain StarCount or Amount (they don't end with "Id")
+        Assert.DoesNotContain(result.Changes, c => c.MemberName == "StarCount");
+        Assert.DoesNotContain(result.Changes, c => c.MemberName == "Amount");
+    }
+
+    [Fact]
+    public async Task Compare_WithMemberFilterOR_MatchesMultiple()
+    {
+        // Test OR logic: "StarCount|TopicId|Amount"
+        var result = await CompareTestLibrariesAsync(memberFilter: "StarCount|TopicId|Amount");
+
+        Assert.True(result.Changes.Count > 0, "Should have changes for OR filter");
+        Assert.Equal("StarCount|TopicId|Amount", result.MemberNameFilter);
+
+        // All changes should match one of the three patterns
+        Assert.All(result.Changes, c =>
+        {
+            var isMatch = c.MemberName == "StarCount" ||
+                         c.MemberName == "TopicId" ||
+                         c.MemberName == "Amount";
+            Assert.True(isMatch, $"Member {c.MemberName} should match StarCount|TopicId|Amount");
+        });
+
+        // Should find all three
+        Assert.Contains(result.Changes, c => c.MemberName == "StarCount");
+        Assert.Contains(result.Changes, c => c.MemberName == "TopicId");
+        Assert.Contains(result.Changes, c => c.MemberName == "Amount");
+
+        // Should NOT contain GetValue or CalculateTotal
+        Assert.DoesNotContain(result.Changes, c => c.MemberName == "GetValue");
+        Assert.DoesNotContain(result.Changes, c => c.MemberName == "CalculateTotal");
+    }
+
+    [Fact]
+    public async Task Compare_WithTypeAndMemberFilter_BothApplied()
+    {
+        // Test combination of typeFilter and memberFilter
+        var result = await CompareTestLibrariesAsync(
+            typeFilter: "ClassForMemberFilter",
+            memberFilter: "*Count");
+
+        Assert.True(result.Changes.Count > 0, "Should have changes matching both filters");
+        Assert.Equal("ClassForMemberFilter", result.TypeNameFilter);
+        Assert.Equal("*Count", result.MemberNameFilter);
+
+        // All changes should be from ClassForMemberFilter AND have member names ending with "Count"
+        Assert.All(result.Changes, c =>
+        {
+            Assert.Equal("ClassForMemberFilter", c.TypeName);
+            Assert.NotNull(c.MemberName);
+            Assert.EndsWith("Count", c.MemberName);
+        });
+
+        // Should find StarCount in ClassForMemberFilter
+        Assert.Contains(result.Changes, c =>
+            c.TypeName == "ClassForMemberFilter" &&
+            c.MemberName == "StarCount");
+
+        // Should NOT contain AnotherClassWithMembers (filtered by type)
+        Assert.DoesNotContain(result.Changes, c => c.TypeName == "AnotherClassWithMembers");
+
+        // Should NOT contain TopicId from ClassForMemberFilter (doesn't end with "Count")
+        Assert.DoesNotContain(result.Changes, c =>
+            c.TypeName == "ClassForMemberFilter" &&
+            c.MemberName == "TopicId");
+    }
+
+    // Helper method to compare TestLibrary.V1 and V2
+    private Task<ComparisonResult> CompareTestLibrariesAsync(
+        string? typeFilter = null,
+        string? memberFilter = null,
+        bool breakingChangesOnly = false,
+        int maxChangesPerCategory = 100)
+    {
+        // Get paths to the test library assemblies
+        // Use the workspace root to find the assemblies
+        var workspaceRoot = "/workspaces/NugetMcpServer";
+        var v1Path = Path.Combine(workspaceRoot, "TestLibraries", "TestLibrary.V1", "bin", "Debug", "net9.0", "TestLibrary.V1.dll");
+        var v2Path = Path.Combine(workspaceRoot, "TestLibraries", "TestLibrary.V2", "bin", "Debug", "net9.0", "TestLibrary.V2.dll");
+
+        // Verify files exist
+        Assert.True(File.Exists(v1Path), $"V1 assembly not found at: {v1Path}");
+        Assert.True(File.Exists(v2Path), $"V2 assembly not found at: {v2Path}");
+
+        // Load assemblies in separate contexts
+        var v1Context = new AssemblyLoadContext($"TestLibrary.V1-{Guid.NewGuid()}", isCollectible: true);
+        var v2Context = new AssemblyLoadContext($"TestLibrary.V2-{Guid.NewGuid()}", isCollectible: true);
+
+        try
+        {
+            var v1Assembly = v1Context.LoadFromAssemblyPath(v1Path);
+            var v2Assembly = v2Context.LoadFromAssemblyPath(v2Path);
+
+            var v1Types = GetPublicTypes(v1Assembly, typeFilter);
+            var v2Types = GetPublicTypes(v2Assembly, typeFilter);
+
+            // Create type comparer with null logger for tests
+            var documentationProvider = new DocumentationProvider();
+            var comparer = new TypeComparer(documentationProvider);
+
+            // Detect changes
+            var changes = new List<TypeChange>();
+
+            // Build dictionaries by full name
+            var oldTypeDict = v1Types.ToDictionary(t => t.FullName ?? t.Name);
+            var newTypeDict = v2Types.ToDictionary(t => t.FullName ?? t.Name);
+
+            // Find removed types
+            foreach (var (fullName, type) in oldTypeDict)
+            {
+                if (!newTypeDict.ContainsKey(fullName))
+                {
+                    changes.Add(comparer.CreateTypeRemovedChange(type));
+                }
+            }
+
+            // Find added types
+            foreach (var (fullName, type) in newTypeDict)
+            {
+                if (!oldTypeDict.ContainsKey(fullName))
+                {
+                    changes.Add(comparer.CreateTypeAddedChange(type));
+                }
+            }
+
+            // Compare existing types
+            foreach (var (fullName, oldType) in oldTypeDict)
+            {
+                if (newTypeDict.TryGetValue(fullName, out var newType))
+                {
+                    var typeChanges = comparer.CompareTypes(oldType, newType);
+                    changes.AddRange(typeChanges);
+                }
+            }
+
+            // Store all changes for summary
+            var allChanges = changes.ToList();
+
+            // Apply memberFilter if requested
+            if (!string.IsNullOrWhiteSpace(memberFilter))
+            {
+                var patterns = memberFilter.Split('|', StringSplitOptions.RemoveEmptyEntries);
+                var regexes = patterns.Select(p => {
+                    var pattern = "^" + System.Text.RegularExpressions.Regex.Escape(p.Trim())
+                        .Replace("\\*", ".*")
+                        .Replace("\\?", ".") + "$";
+                    return new System.Text.RegularExpressions.Regex(pattern,
+                        System.Text.RegularExpressions.RegexOptions.IgnoreCase);
+                }).ToList();
+
+                changes = changes.Where(c =>
+                    !string.IsNullOrEmpty(c.MemberName) &&
+                    regexes.Any(r => r.IsMatch(c.MemberName))
+                ).ToList();
+            }
+
+            // Apply breakingChangesOnly filter if requested
+            if (breakingChangesOnly)
+            {
+                changes = changes.Where(c => c.Severity == ChangeSeverity.High).ToList();
+            }
+
+            // Apply per-category limits
+            var limitedChanges = ApplyLimits(changes, maxChangesPerCategory);
+            var isTruncated = limitedChanges.Count < changes.Count;
+
+            // Build result
+            var result = new ComparisonResult
+            {
+                PackageId = "TestLibrary",
+                FromVersion = "1.0.0",
+                ToVersion = "2.0.0",
+                Changes = limitedChanges,
+                Summary = BuildSummary(allChanges),
+                IsTruncated = isTruncated,
+                TypeNameFilter = typeFilter,
+                MemberNameFilter = memberFilter,
+                BreakingChangesOnly = breakingChangesOnly
+            };
+
+            return Task.FromResult(result);
+        }
+        finally
+        {
+            v1Context.Unload();
+            v2Context.Unload();
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+        }
+    }
+
+    private List<Type> GetPublicTypes(Assembly assembly, string? filter)
+    {
+        var types = assembly.GetTypes()
+            .Where(t => t.IsPublic || t.IsNestedPublic)
+            .Where(t => !t.Name.StartsWith("<")) // Skip compiler-generated types
+            .ToList();
+
+        if (!string.IsNullOrWhiteSpace(filter))
+        {
+            var pattern = "^" + System.Text.RegularExpressions.Regex.Escape(filter)
+                .Replace("\\*", ".*")
+                .Replace("\\?", ".") + "$";
+            var regex = new System.Text.RegularExpressions.Regex(pattern,
+                System.Text.RegularExpressions.RegexOptions.IgnoreCase);
+
+            types = types.Where(t =>
+                regex.IsMatch(t.FullName ?? t.Name) ||
+                regex.IsMatch(t.Name)).ToList();
+        }
+
+        return types;
+    }
+
+    private List<TypeChange> ApplyLimits(List<TypeChange> changes, int maxPerCategory)
+    {
+        var result = new List<TypeChange>();
+        var countByCategory = new Dictionary<ChangeCategory, int>();
+
+        foreach (var change in changes)
+        {
+            if (!countByCategory.ContainsKey(change.Category))
+            {
+                countByCategory[change.Category] = 0;
+            }
+
+            if (countByCategory[change.Category] < maxPerCategory)
+            {
+                result.Add(change);
+                countByCategory[change.Category]++;
+            }
+        }
+
+        return result;
+    }
+
+    private ComparisonSummary BuildSummary(List<TypeChange> changes)
+    {
+        var summary = new ComparisonSummary
+        {
+            TotalChanges = changes.Count
+        };
+
+        var breakingCategories = new HashSet<ChangeCategory>
+        {
+            ChangeCategory.TypeRemoved,
+            ChangeCategory.MemberRemoved,
+            ChangeCategory.MemberTypeChanged,
+            ChangeCategory.MethodSignatureChanged,
+            ChangeCategory.ParameterRemoved,
+            ChangeCategory.ParameterTypeChanged,
+            ChangeCategory.ReturnTypeChanged,
+            ChangeCategory.BaseClassChanged,
+            ChangeCategory.InterfaceRemoved,
+            ChangeCategory.AccessibilityReduced,
+            ChangeCategory.SealedAdded,
+            ChangeCategory.AbstractAdded,
+            ChangeCategory.VirtualRemoved,
+            ChangeCategory.EnumValueRemoved,
+            ChangeCategory.GenericParametersChanged
+        };
+
+        var additionCategories = new HashSet<ChangeCategory>
+        {
+            ChangeCategory.TypeAdded,
+            ChangeCategory.MemberAdded,
+            ChangeCategory.MethodOverloadAdded,
+            ChangeCategory.ParameterAdded,
+            ChangeCategory.InterfaceAdded,
+            ChangeCategory.EnumValueAdded
+        };
+
+        var removalCategories = new HashSet<ChangeCategory>
+        {
+            ChangeCategory.TypeRemoved,
+            ChangeCategory.MemberRemoved,
+            ChangeCategory.InterfaceRemoved,
+            ChangeCategory.EnumValueRemoved
+        };
+
+        foreach (var change in changes)
+        {
+            if (!summary.ChangesBySeverity.ContainsKey(change.Severity))
+            {
+                summary.ChangesBySeverity[change.Severity] = 0;
+            }
+            summary.ChangesBySeverity[change.Severity]++;
+
+            if (!summary.ChangesByCategory.ContainsKey(change.Category))
+            {
+                summary.ChangesByCategory[change.Category] = 0;
+            }
+            summary.ChangesByCategory[change.Category]++;
+
+            if (breakingCategories.Contains(change.Category))
+            {
+                summary.BreakingChanges++;
+            }
+            else if (additionCategories.Contains(change.Category))
+            {
+                summary.Additions++;
+            }
+            else
+            {
+                summary.NonBreakingChanges++;
+            }
+
+            if (removalCategories.Contains(change.Category))
+            {
+                summary.Removals++;
+            }
+
+            if (!additionCategories.Contains(change.Category) && !removalCategories.Contains(change.Category))
+            {
+                summary.Modifications++;
+            }
+        }
+
+        return summary;
+    }
+
+    [Fact]
+    public async Task Compare_SameAssemblyDifferentContext_NoFalsePositives()
+    {
+        // This test verifies that TypeComparer.AreTypesEquivalent correctly ignores assembly version differences
+        // by loading the same assembly twice in different contexts (which gives them different runtime versions)
+
+        var workspaceRoot = "/workspaces/NugetMcpServer";
+        var v1Path = Path.Combine(workspaceRoot, "TestLibraries", "TestLibrary.V1", "bin", "Debug", "net9.0", "TestLibrary.V1.dll");
+
+        Assert.True(File.Exists(v1Path), $"V1 assembly not found at: {v1Path}");
+
+        // Load the SAME assembly in two different contexts
+        var context1 = new AssemblyLoadContext($"TestLibrary.V1-Context1-{Guid.NewGuid()}", isCollectible: true);
+        var context2 = new AssemblyLoadContext($"TestLibrary.V1-Context2-{Guid.NewGuid()}", isCollectible: true);
+
+        try
+        {
+            var assembly1 = context1.LoadFromAssemblyPath(v1Path);
+            var assembly2 = context2.LoadFromAssemblyPath(v1Path);
+
+            var types1 = GetPublicTypes(assembly1, null);
+            var types2 = GetPublicTypes(assembly2, null);
+
+            Assert.True(types1.Count > 0, "Should have loaded some types");
+            Assert.Equal(types1.Count, types2.Count);
+
+            var documentationProvider = new DocumentationProvider();
+            var comparer = new TypeComparer(documentationProvider);
+
+            // Build dictionaries
+            var typeDict1 = types1.ToDictionary(t => t.FullName ?? t.Name);
+            var typeDict2 = types2.ToDictionary(t => t.FullName ?? t.Name);
+
+            // Compare types
+            var changes = new List<TypeChange>();
+            foreach (var (fullName, type1) in typeDict1)
+            {
+                if (typeDict2.TryGetValue(fullName, out var type2))
+                {
+                    var typeChanges = comparer.CompareTypes(type1, type2);
+                    changes.AddRange(typeChanges);
+                }
+            }
+
+            // Should have NO changes because it's the same assembly
+            // (any changes would be false positives due to assembly version comparison)
+            Assert.Empty(changes);
+        }
+        finally
+        {
+            context1.Unload();
+            context2.Unload();
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+        }
+    }
+
+    // === OPTIONAL PARAMETERS TESTS ===
+
+    [Fact]
+    public async Task Compare_DetectsNonBreaking_CompatibleOverloadWithOptionalParams()
+    {
+        // ClassWithOptionalParamsAdded: methods in V2 add optional parameters to V1 signatures
+        // This should be detected as MethodOverloadAdded (non-breaking) instead of MemberRemoved + MemberAdded
+        var result = await CompareTestLibrariesAsync();
+
+        // SendMessage: string text → string text, int? threadId = null
+        var sendMessageChanges = result.Changes.Where(c =>
+            c.TypeName == "ClassWithOptionalParamsAdded" &&
+            c.MemberName == "SendMessage").ToList();
+
+        // Should have exactly ONE change: MethodOverloadAdded
+        Assert.Single(sendMessageChanges);
+        Assert.Equal(ChangeCategory.MethodOverloadAdded, sendMessageChanges[0].Category);
+        Assert.Equal(ChangeSeverity.Low, sendMessageChanges[0].Severity);
+
+        // Calculate: (int a, int b) → (int a, int b, int c = 0, int d = 0)
+        var calculateChanges = result.Changes.Where(c =>
+            c.TypeName == "ClassWithOptionalParamsAdded" &&
+            c.MemberName == "Calculate").ToList();
+
+        Assert.Single(calculateChanges);
+        Assert.Equal(ChangeCategory.MethodOverloadAdded, calculateChanges[0].Category);
+        Assert.Equal(ChangeSeverity.Low, calculateChanges[0].Severity);
+
+        // FormatText: (string input) → (string input, bool uppercase = false)
+        var formatChanges = result.Changes.Where(c =>
+            c.TypeName == "ClassWithOptionalParamsAdded" &&
+            c.MemberName == "FormatText").ToList();
+
+        Assert.Single(formatChanges);
+        Assert.Equal(ChangeCategory.MethodOverloadAdded, formatChanges[0].Category);
+        Assert.Equal(ChangeSeverity.Low, formatChanges[0].Severity);
+    }
+
+    [Fact]
+    public async Task Compare_DetectsBreaking_IncompatibleOverloadWithRequiredParams()
+    {
+        // ClassWithRequiredParamsAdded: ProcessData adds a REQUIRED parameter (not optional)
+        // This should be detected as MemberRemoved + MemberAdded (breaking)
+        var result = await CompareTestLibrariesAsync();
+
+        var changes = result.Changes.Where(c =>
+            c.TypeName == "ClassWithRequiredParamsAdded" &&
+            c.MemberName == "ProcessData").ToList();
+
+        // Should have TWO changes: one Removed and one Added (because new param is NOT optional)
+        Assert.Equal(2, changes.Count);
+        Assert.Contains(changes, c => c.Category == ChangeCategory.MemberRemoved);
+        Assert.Contains(changes, c => c.Category == ChangeCategory.MemberAdded);
+
+        // Both should be detected as breaking/additions
+        Assert.Contains(changes, c => c.Severity == ChangeSeverity.High);
+    }
+
+    [Fact]
+    public async Task Compare_DetectsNonBreaking_TrueOverloadWhileOldRemains()
+    {
+        // ClassWithTrueOverload: V2 adds new overload Execute(string, int)
+        // while keeping old Execute(string)
+        // This should show ONLY MemberAdded for the new overload (non-breaking)
+        var result = await CompareTestLibrariesAsync();
+
+        var changes = result.Changes.Where(c =>
+            c.TypeName == "ClassWithTrueOverload" &&
+            c.MemberName == "Execute").ToList();
+
+        // Should have exactly ONE change: MemberAdded for the new overload
+        Assert.Single(changes);
+        Assert.Equal(ChangeCategory.MemberAdded, changes[0].Category);
+        Assert.Equal(ChangeSeverity.Low, changes[0].Severity);
+
+        // Should contain the signature with two parameters
+        Assert.Contains("Int32", changes[0].To);
+    }
+
+    [Fact]
+    public async Task Compare_DetectsBreaking_ParameterReordering()
+    {
+        // ClassWithParamReordering: ConfigureSettings changes parameter order
+        // V1: (string name, int value, bool enabled)
+        // V2: (int value, string name, bool enabled)
+        // This is BREAKING - old calls will fail
+        var result = await CompareTestLibrariesAsync();
+
+        var changes = result.Changes.Where(c =>
+            c.TypeName == "ClassWithParamReordering" &&
+            c.MemberName == "ConfigureSettings").ToList();
+
+        // Should detect as MemberRemoved + MemberAdded (signatures don't match)
+        Assert.Equal(2, changes.Count);
+        Assert.Contains(changes, c => c.Category == ChangeCategory.MemberRemoved);
+        Assert.Contains(changes, c => c.Category == ChangeCategory.MemberAdded);
+
+        // Should be breaking
+        Assert.Contains(changes, c => c.Severity == ChangeSeverity.High);
+    }
+}

--- a/NugetMcpServer.sln
+++ b/NugetMcpServer.sln
@@ -7,6 +7,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NugetMcpServer", "NugetMcpS
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NugetMcpServer.Tests", "NugetMcpServer.Tests\NugetMcpServer.Tests.csproj", "{30AD02FD-13AA-4C37-A0CB-9E2E633C65CD}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestLibrary.V1", "TestLibraries\TestLibrary.V1\TestLibrary.V1.csproj", "{A1B2C3D4-E5F6-4A5B-8C9D-0E1F2A3B4C5D}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestLibrary.V2", "TestLibraries\TestLibrary.V2\TestLibrary.V2.csproj", "{B2C3D4E5-F6A7-4B5C-9D0E-1F2A3B4C5D6E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -21,6 +25,14 @@ Global
 		{30AD02FD-13AA-4C37-A0CB-9E2E633C65CD}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{30AD02FD-13AA-4C37-A0CB-9E2E633C65CD}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{30AD02FD-13AA-4C37-A0CB-9E2E633C65CD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A1B2C3D4-E5F6-4A5B-8C9D-0E1F2A3B4C5D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A1B2C3D4-E5F6-4A5B-8C9D-0E1F2A3B4C5D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A1B2C3D4-E5F6-4A5B-8C9D-0E1F2A3B4C5D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A1B2C3D4-E5F6-4A5B-8C9D-0E1F2A3B4C5D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B2C3D4E5-F6A7-4B5C-9D0E-1F2A3B4C5D6E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B2C3D4E5-F6A7-4B5C-9D0E-1F2A3B4C5D6E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B2C3D4E5-F6A7-4B5C-9D0E-1F2A3B4C5D6E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B2C3D4E5-F6A7-4B5C-9D0E-1F2A3B4C5D6E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/NugetMcpServer/Models/ChangeCategory.cs
+++ b/NugetMcpServer/Models/ChangeCategory.cs
@@ -1,0 +1,69 @@
+namespace NuGetMcpServer.Models;
+
+/// <summary>
+/// Categories of changes between package versions
+/// </summary>
+public enum ChangeCategory
+{
+    // Breaking changes - type level
+    TypeRemoved,
+    BaseClassChanged,
+    InterfaceRemoved,
+    SealedAdded,
+    AbstractAdded,
+    GenericParametersChanged,
+
+    // Breaking changes - member level
+    MemberRemoved,
+    MemberTypeChanged,
+    MethodSignatureChanged,
+    ParameterRemoved,
+    ParameterTypeChanged,
+    ReturnTypeChanged,
+    VirtualRemoved,
+    AccessibilityReduced,
+
+    // Breaking changes - enum
+    EnumValueRemoved,
+
+    // Non-breaking changes
+    MemberObsoleted,
+    AccessibilityExpanded,
+    ParameterDefaultChanged,
+
+    // Additions
+    TypeAdded,
+    MemberAdded,
+    MethodOverloadAdded,
+    ParameterAdded,
+    InterfaceAdded,
+    EnumValueAdded,
+
+    // Metadata changes
+    DependencyVersionChanged,
+    DependencyAdded,
+    DependencyRemoved,
+    TargetFrameworkAdded,
+    TargetFrameworkRemoved
+}
+
+/// <summary>
+/// Severity level of a change
+/// </summary>
+public enum ChangeSeverity
+{
+    /// <summary>
+    /// Low severity - unlikely to break existing code
+    /// </summary>
+    Low,
+
+    /// <summary>
+    /// Medium severity - may break existing code in some scenarios
+    /// </summary>
+    Medium,
+
+    /// <summary>
+    /// High severity - likely to break existing code
+    /// </summary>
+    High
+}

--- a/NugetMcpServer/Models/TypeChange.cs
+++ b/NugetMcpServer/Models/TypeChange.cs
@@ -1,0 +1,67 @@
+namespace NuGetMcpServer.Models;
+
+/// <summary>
+/// Represents a change detected between two versions of a package
+/// </summary>
+public class TypeChange
+{
+    /// <summary>
+    /// Category of the change
+    /// </summary>
+    public ChangeCategory Category { get; set; }
+
+    /// <summary>
+    /// Severity of the change
+    /// </summary>
+    public ChangeSeverity Severity { get; set; }
+
+    /// <summary>
+    /// Simple name of the affected type
+    /// </summary>
+    public string TypeName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Full name of the affected type including namespace
+    /// </summary>
+    public string? TypeFullName { get; set; }
+
+    /// <summary>
+    /// Name of the affected member (method, property, field, etc.)
+    /// </summary>
+    public string? MemberName { get; set; }
+
+    /// <summary>
+    /// Original value/signature (for modifications)
+    /// </summary>
+    public string? From { get; set; }
+
+    /// <summary>
+    /// New value/signature (for modifications)
+    /// </summary>
+    public string? To { get; set; }
+
+    /// <summary>
+    /// Original type (for type changes)
+    /// </summary>
+    public string? FromType { get; set; }
+
+    /// <summary>
+    /// New type (for type changes)
+    /// </summary>
+    public string? ToType { get; set; }
+
+    /// <summary>
+    /// XML documentation comment for the changed member
+    /// </summary>
+    public string? Documentation { get; set; }
+
+    /// <summary>
+    /// Description of the impact of this change
+    /// </summary>
+    public string? Impact { get; set; }
+
+    /// <summary>
+    /// Suggested migration path for breaking changes
+    /// </summary>
+    public string? Migration { get; set; }
+}

--- a/NugetMcpServer/Program.cs
+++ b/NugetMcpServer/Program.cs
@@ -43,6 +43,8 @@ internal class Program
         builder.Services.AddSingleton<InterfaceFormattingService>();
         builder.Services.AddSingleton<EnumFormattingService>();
         builder.Services.AddSingleton<ClassFormattingService>();
+        builder.Services.AddSingleton<DocumentationProvider>();
+        builder.Services.AddSingleton<PackageComparisonService>();
 
         builder.Services
             .AddMcpServer()

--- a/NugetMcpServer/Services/ComparisonResult.cs
+++ b/NugetMcpServer/Services/ComparisonResult.cs
@@ -1,0 +1,101 @@
+using System.Collections.Generic;
+using NuGetMcpServer.Models;
+
+namespace NuGetMcpServer.Services;
+
+/// <summary>
+/// Result of comparing two package versions
+/// </summary>
+public class ComparisonResult
+{
+    /// <summary>
+    /// Package identifier
+    /// </summary>
+    public string PackageId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Older version being compared
+    /// </summary>
+    public string FromVersion { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Newer version being compared
+    /// </summary>
+    public string ToVersion { get; set; } = string.Empty;
+
+    /// <summary>
+    /// All detected changes
+    /// </summary>
+    public List<TypeChange> Changes { get; set; } = new();
+
+    /// <summary>
+    /// Summary statistics
+    /// </summary>
+    public ComparisonSummary Summary { get; set; } = new();
+
+    /// <summary>
+    /// Whether this comparison was truncated due to limits
+    /// </summary>
+    public bool IsTruncated { get; set; }
+
+    /// <summary>
+    /// Type name filter applied during comparison (if any). Filters by type names (classes, structs, records, interfaces), not field/property names.
+    /// </summary>
+    public string? TypeNameFilter { get; set; }
+
+    /// <summary>
+    /// Member name filter applied during comparison (if any). Filters by member names (properties, fields, methods), not type names.
+    /// </summary>
+    public string? MemberNameFilter { get; set; }
+
+    /// <summary>
+    /// Whether only breaking changes were included in results
+    /// </summary>
+    public bool BreakingChangesOnly { get; set; }
+}
+
+/// <summary>
+/// Summary statistics for a comparison
+/// </summary>
+public class ComparisonSummary
+{
+    /// <summary>
+    /// Total number of changes detected
+    /// </summary>
+    public int TotalChanges { get; set; }
+
+    /// <summary>
+    /// Number of breaking changes
+    /// </summary>
+    public int BreakingChanges { get; set; }
+
+    /// <summary>
+    /// Number of non-breaking changes
+    /// </summary>
+    public int NonBreakingChanges { get; set; }
+
+    /// <summary>
+    /// Number of additions
+    /// </summary>
+    public int Additions { get; set; }
+
+    /// <summary>
+    /// Number of removals
+    /// </summary>
+    public int Removals { get; set; }
+
+    /// <summary>
+    /// Number of modifications
+    /// </summary>
+    public int Modifications { get; set; }
+
+    /// <summary>
+    /// Changes grouped by category
+    /// </summary>
+    public Dictionary<ChangeCategory, int> ChangesByCategory { get; set; } = new();
+
+    /// <summary>
+    /// Changes grouped by severity
+    /// </summary>
+    public Dictionary<ChangeSeverity, int> ChangesBySeverity { get; set; } = new();
+}

--- a/NugetMcpServer/Services/DocumentationProvider.cs
+++ b/NugetMcpServer/Services/DocumentationProvider.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Reflection;
+
+namespace NuGetMcpServer.Services;
+
+/// <summary>
+/// Provides XML documentation comments for types and members
+/// </summary>
+public class DocumentationProvider
+{
+    /// <summary>
+    /// Get documentation for a type
+    /// </summary>
+    public string? GetDocumentation(Type type)
+    {
+        // TODO: Implement XML documentation parsing
+        // For now, return null - documentation extraction can be added later
+        return null;
+    }
+
+    /// <summary>
+    /// Get documentation for a member
+    /// </summary>
+    public string? GetDocumentation(MemberInfo member)
+    {
+        // TODO: Implement XML documentation parsing
+        // For now, return null - documentation extraction can be added later
+        return null;
+    }
+
+    /// <summary>
+    /// Get documentation for an enum value
+    /// </summary>
+    public string? GetDocumentation(Type enumType, string valueName)
+    {
+        // TODO: Implement XML documentation parsing
+        // For now, return null - documentation extraction can be added later
+        return null;
+    }
+}

--- a/NugetMcpServer/Services/PackageComparisonService.cs
+++ b/NugetMcpServer/Services/PackageComparisonService.cs
@@ -1,0 +1,325 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Loader;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using NuGetMcpServer.Common;
+using NuGetMcpServer.Extensions;
+using NuGetMcpServer.Models;
+
+namespace NuGetMcpServer.Services;
+
+/// <summary>
+/// Service for comparing two versions of a NuGet package
+/// </summary>
+public class PackageComparisonService
+{
+    private readonly ArchiveProcessingService _archiveProcessingService;
+    private readonly DocumentationProvider _documentationProvider;
+    private readonly ILogger<PackageComparisonService> _logger;
+
+    public PackageComparisonService(
+        ArchiveProcessingService archiveProcessingService,
+        DocumentationProvider documentationProvider,
+        ILogger<PackageComparisonService> logger)
+    {
+        _archiveProcessingService = archiveProcessingService;
+        _documentationProvider = documentationProvider;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Compare two versions of a package and detect all changes
+    /// </summary>
+    /// <param name="packageId">Package identifier</param>
+    /// <param name="fromVersion">Older version</param>
+    /// <param name="toVersion">Newer version</param>
+    /// <param name="typeNameFilter">Optional wildcard filter for type names (classes, structs, records, interfaces). Filters by type name, not field/property names.</param>
+    /// <param name="memberNameFilter">Optional wildcard filter for member names (properties, fields, methods). Supports OR via '|'. Filters by member name, not type names.</param>
+    /// <param name="breakingChangesOnly">If true, returns only breaking changes (high severity)</param>
+    /// <param name="maxChangesPerCategory">Maximum changes to return per category</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    public async Task<ComparisonResult> CompareVersionsAsync(
+        string packageId,
+        string fromVersion,
+        string toVersion,
+        string? typeNameFilter = null,
+        string? memberNameFilter = null,
+        bool breakingChangesOnly = false,
+        int maxChangesPerCategory = 100,
+        CancellationToken cancellationToken = default)
+    {
+        LoadedPackageAssemblies? oldLoaded = null;
+        LoadedPackageAssemblies? newLoaded = null;
+
+        try
+        {
+            var progress = ProgressNotifier.VoidProgressNotifier;
+
+            // Load both versions with separate load contexts
+            _logger.LogInformation("Loading old version {FromVersion}", fromVersion);
+            (LoadedPackageAssemblies oldPackage, PackageInfo _, string _) = await _archiveProcessingService.LoadPackageAssembliesAsync(
+                packageId, fromVersion, progress);
+            oldLoaded = oldPackage;
+
+            _logger.LogInformation("Loading new version {ToVersion}", toVersion);
+            (LoadedPackageAssemblies newPackage, PackageInfo _, string _) = await _archiveProcessingService.LoadPackageAssembliesAsync(
+                packageId, toVersion, progress);
+            newLoaded = newPackage;
+
+            if (oldLoaded.Assemblies.Count == 0 || newLoaded.Assemblies.Count == 0)
+            {
+                throw new InvalidOperationException("No assemblies found in one or both package versions");
+            }
+
+            // Get all public types from both versions
+            var oldTypes = GetPublicTypes(oldLoaded.Assemblies, typeNameFilter);
+            var newTypes = GetPublicTypes(newLoaded.Assemblies, typeNameFilter);
+
+            _logger.LogInformation(
+                "Found {OldCount} types in old version, {NewCount} types in new version",
+                oldTypes.Count, newTypes.Count);
+
+            // Create type comparer
+            var comparer = new TypeComparer(_documentationProvider);
+
+            // Detect changes
+            var changes = new List<TypeChange>();
+
+            // Build dictionaries by full name for comparison
+            var oldTypeDict = oldTypes.ToDictionary(t => t.FullName ?? t.Name);
+            var newTypeDict = newTypes.ToDictionary(t => t.FullName ?? t.Name);
+
+            // Find removed types
+            foreach (var (fullName, type) in oldTypeDict)
+            {
+                if (!newTypeDict.ContainsKey(fullName))
+                {
+                    changes.Add(comparer.CreateTypeRemovedChange(type));
+                }
+            }
+
+            // Find added types
+            foreach (var (fullName, type) in newTypeDict)
+            {
+                if (!oldTypeDict.ContainsKey(fullName))
+                {
+                    changes.Add(comparer.CreateTypeAddedChange(type));
+                }
+            }
+
+            // Compare existing types
+            foreach (var (fullName, oldType) in oldTypeDict)
+            {
+                if (newTypeDict.TryGetValue(fullName, out var newType))
+                {
+                    var typeChanges = comparer.CompareTypes(oldType, newType);
+                    changes.AddRange(typeChanges);
+                }
+            }
+
+            _logger.LogInformation("Detected {ChangeCount} total changes", changes.Count);
+
+            // Store all changes for summary (before any filtering)
+            var allChanges = changes.ToList();
+
+            // Apply memberNameFilter if requested
+            if (!string.IsNullOrWhiteSpace(memberNameFilter))
+            {
+                var patterns = memberNameFilter.Split('|', StringSplitOptions.RemoveEmptyEntries);
+                var regexes = patterns.Select(p => {
+                    var pattern = "^" + Regex.Escape(p.Trim())
+                        .Replace("\\*", ".*")
+                        .Replace("\\?", ".") + "$";
+                    return new Regex(pattern, RegexOptions.IgnoreCase);
+                }).ToList();
+
+                changes = changes.Where(c =>
+                    !string.IsNullOrEmpty(c.MemberName) &&
+                    regexes.Any(r => r.IsMatch(c.MemberName))
+                ).ToList();
+
+                _logger.LogInformation("Filtered to {Count} changes by member name", changes.Count);
+            }
+
+            // Apply breakingChangesOnly filter if requested
+            if (breakingChangesOnly)
+            {
+                changes = changes.Where(c => c.Severity == ChangeSeverity.High).ToList();
+                _logger.LogInformation("Filtered to {Count} breaking changes only", changes.Count);
+            }
+
+            // Apply per-category limits
+            var limitedChanges = ApplyLimits(changes, maxChangesPerCategory);
+            var isTruncated = limitedChanges.Count < changes.Count;
+
+            // Build result
+            var result = new ComparisonResult
+            {
+                PackageId = packageId,
+                FromVersion = fromVersion,
+                ToVersion = toVersion,
+                Changes = limitedChanges,
+                Summary = BuildSummary(allChanges), // Use full changes for accurate summary
+                IsTruncated = isTruncated,
+                TypeNameFilter = typeNameFilter,
+                MemberNameFilter = memberNameFilter,
+                BreakingChangesOnly = breakingChangesOnly
+            };
+
+            return result;
+        }
+        finally
+        {
+            // Unload contexts to free memory
+            oldLoaded?.AssemblyLoadContext.Unload();
+            newLoaded?.AssemblyLoadContext.Unload();
+
+            // Force GC to clean up unloaded assemblies
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+        }
+    }
+
+    private List<Type> GetPublicTypes(List<LoadedAssemblyInfo> assemblies, string? typeNameFilter)
+    {
+        var types = new List<Type>();
+        Regex? filterRegex = null;
+
+        if (!string.IsNullOrWhiteSpace(typeNameFilter))
+        {
+            // Convert wildcard pattern to regex
+            var pattern = "^" + Regex.Escape(typeNameFilter).Replace("\\*", ".*").Replace("\\?", ".") + "$";
+            filterRegex = new Regex(pattern, RegexOptions.IgnoreCase);
+        }
+
+        foreach (var assemblyInfo in assemblies)
+        {
+            var assemblyTypes = assemblyInfo.Types
+                .Where(t => t.IsPublic || t.IsNestedPublic)
+                .Where(t => !t.Name.StartsWith("<")) // Skip compiler-generated types
+                .Where(t => filterRegex == null ||
+                           filterRegex.IsMatch(t.FullName ?? t.Name) ||
+                           filterRegex.IsMatch(t.Name));
+
+            types.AddRange(assemblyTypes);
+        }
+
+        return types;
+    }
+
+    private List<TypeChange> ApplyLimits(List<TypeChange> changes, int maxPerCategory)
+    {
+        var result = new List<TypeChange>();
+        var countByCategory = new Dictionary<ChangeCategory, int>();
+
+        foreach (var change in changes)
+        {
+            if (!countByCategory.ContainsKey(change.Category))
+            {
+                countByCategory[change.Category] = 0;
+            }
+
+            if (countByCategory[change.Category] < maxPerCategory)
+            {
+                result.Add(change);
+                countByCategory[change.Category]++;
+            }
+        }
+
+        return result;
+    }
+
+    private ComparisonSummary BuildSummary(List<TypeChange> changes)
+    {
+        var summary = new ComparisonSummary
+        {
+            TotalChanges = changes.Count
+        };
+
+        // Categorize changes
+        var breakingCategories = new HashSet<ChangeCategory>
+        {
+            ChangeCategory.TypeRemoved,
+            ChangeCategory.MemberRemoved,
+            ChangeCategory.MemberTypeChanged,
+            ChangeCategory.MethodSignatureChanged,
+            ChangeCategory.ParameterRemoved,
+            ChangeCategory.ParameterTypeChanged,
+            ChangeCategory.ReturnTypeChanged,
+            ChangeCategory.BaseClassChanged,
+            ChangeCategory.InterfaceRemoved,
+            ChangeCategory.AccessibilityReduced,
+            ChangeCategory.SealedAdded,
+            ChangeCategory.AbstractAdded,
+            ChangeCategory.VirtualRemoved,
+            ChangeCategory.EnumValueRemoved,
+            ChangeCategory.GenericParametersChanged
+        };
+
+        var additionCategories = new HashSet<ChangeCategory>
+        {
+            ChangeCategory.TypeAdded,
+            ChangeCategory.MemberAdded,
+            ChangeCategory.MethodOverloadAdded,
+            ChangeCategory.ParameterAdded,
+            ChangeCategory.InterfaceAdded,
+            ChangeCategory.EnumValueAdded
+        };
+
+        var removalCategories = new HashSet<ChangeCategory>
+        {
+            ChangeCategory.TypeRemoved,
+            ChangeCategory.MemberRemoved,
+            ChangeCategory.InterfaceRemoved,
+            ChangeCategory.EnumValueRemoved
+        };
+
+        foreach (var change in changes)
+        {
+            // Count by severity
+            if (!summary.ChangesBySeverity.ContainsKey(change.Severity))
+            {
+                summary.ChangesBySeverity[change.Severity] = 0;
+            }
+            summary.ChangesBySeverity[change.Severity]++;
+
+            // Count by category
+            if (!summary.ChangesByCategory.ContainsKey(change.Category))
+            {
+                summary.ChangesByCategory[change.Category] = 0;
+            }
+            summary.ChangesByCategory[change.Category]++;
+
+            // Categorize
+            if (breakingCategories.Contains(change.Category))
+            {
+                summary.BreakingChanges++;
+            }
+            else if (additionCategories.Contains(change.Category))
+            {
+                summary.Additions++;
+            }
+            else
+            {
+                summary.NonBreakingChanges++;
+            }
+
+            if (removalCategories.Contains(change.Category))
+            {
+                summary.Removals++;
+            }
+
+            if (!additionCategories.Contains(change.Category) && !removalCategories.Contains(change.Category))
+            {
+                summary.Modifications++;
+            }
+        }
+
+        return summary;
+    }
+}

--- a/NugetMcpServer/Services/TypeComparer.cs
+++ b/NugetMcpServer/Services/TypeComparer.cs
@@ -1,0 +1,727 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using NuGetMcpServer.Models;
+
+namespace NuGetMcpServer.Services;
+
+/// <summary>
+/// Compares types between two assemblies and detects changes
+/// </summary>
+public class TypeComparer
+{
+    private readonly DocumentationProvider _documentationProvider;
+
+    public TypeComparer(DocumentationProvider documentationProvider)
+    {
+        _documentationProvider = documentationProvider;
+    }
+
+    /// <summary>
+    /// Compare two types and detect all changes
+    /// </summary>
+    public List<TypeChange> CompareTypes(Type oldType, Type newType)
+    {
+        var changes = new List<TypeChange>();
+
+        // Compare base class
+        if (!AreTypesEquivalent(oldType.BaseType, newType.BaseType))
+        {
+            changes.Add(new TypeChange
+            {
+                Category = ChangeCategory.BaseClassChanged,
+                Severity = ChangeSeverity.High,
+                TypeName = newType.Name,
+                TypeFullName = newType.FullName,
+                FromType = oldType.BaseType != null ? GetTypeIdentifier(oldType.BaseType) : null,
+                ToType = newType.BaseType != null ? GetTypeIdentifier(newType.BaseType) : null,
+                Impact = "Base class change may break inheritance-based code",
+                Migration = "Review derived classes and ensure compatibility with new base class"
+            });
+        }
+
+        // Compare interfaces (using type identifier without version)
+        var oldInterfacesDict = oldType.GetInterfaces().ToDictionary(i => GetTypeIdentifier(i), i => i);
+        var newInterfacesDict = newType.GetInterfaces().ToDictionary(i => GetTypeIdentifier(i), i => i);
+
+        foreach (var (identifier, interfaceType) in oldInterfacesDict)
+        {
+            if (!newInterfacesDict.ContainsKey(identifier))
+            {
+                changes.Add(new TypeChange
+                {
+                    Category = ChangeCategory.InterfaceRemoved,
+                    Severity = ChangeSeverity.High,
+                    TypeName = newType.Name,
+                    TypeFullName = newType.FullName,
+                    From = identifier,
+                    Impact = $"Interface {identifier} removed - code expecting this interface will break",
+                    Migration = $"Update code to not rely on {identifier} interface"
+                });
+            }
+        }
+
+        foreach (var (identifier, interfaceType) in newInterfacesDict)
+        {
+            if (!oldInterfacesDict.ContainsKey(identifier))
+            {
+                changes.Add(new TypeChange
+                {
+                    Category = ChangeCategory.InterfaceAdded,
+                    Severity = ChangeSeverity.Low,
+                    TypeName = newType.Name,
+                    TypeFullName = newType.FullName,
+                    To = identifier,
+                    Impact = "New interface added - non-breaking change"
+                });
+            }
+        }
+
+        // Compare type modifiers
+        if (!oldType.IsSealed && newType.IsSealed)
+        {
+            changes.Add(new TypeChange
+            {
+                Category = ChangeCategory.SealedAdded,
+                Severity = ChangeSeverity.High,
+                TypeName = newType.Name,
+                TypeFullName = newType.FullName,
+                Impact = "Type is now sealed - inheritance no longer possible",
+                Migration = "Remove inheritance from this type or use composition"
+            });
+        }
+
+        if (!oldType.IsAbstract && newType.IsAbstract)
+        {
+            changes.Add(new TypeChange
+            {
+                Category = ChangeCategory.AbstractAdded,
+                Severity = ChangeSeverity.High,
+                TypeName = newType.Name,
+                TypeFullName = newType.FullName,
+                Impact = "Type is now abstract - direct instantiation no longer possible",
+                Migration = "Use derived concrete types instead"
+            });
+        }
+
+        // Compare generic parameters
+        var oldGenericArgs = oldType.GetGenericArguments();
+        var newGenericArgs = newType.GetGenericArguments();
+
+        if (oldGenericArgs.Length != newGenericArgs.Length)
+        {
+            changes.Add(new TypeChange
+            {
+                Category = ChangeCategory.GenericParametersChanged,
+                Severity = ChangeSeverity.High,
+                TypeName = newType.Name,
+                TypeFullName = newType.FullName,
+                From = $"{oldGenericArgs.Length} generic parameters",
+                To = $"{newGenericArgs.Length} generic parameters",
+                Impact = "Generic parameter count changed - breaks all usage",
+                Migration = "Update all references to use new generic parameter signature"
+            });
+        }
+
+        // Compare members
+        if (oldType.IsEnum && newType.IsEnum)
+        {
+            changes.AddRange(CompareEnumValues(oldType, newType));
+        }
+        else
+        {
+            changes.AddRange(CompareMembers(oldType, newType));
+        }
+
+        return changes;
+    }
+
+    /// <summary>
+    /// Compare properties and fields for type changes
+    /// </summary>
+    private List<TypeChange> ComparePropertiesAndFields(Type oldType, Type newType, BindingFlags flags)
+    {
+        var changes = new List<TypeChange>();
+
+        // Compare properties
+        var oldProps = oldType.GetProperties(flags).ToDictionary(p => p.Name);
+        var newProps = newType.GetProperties(flags).ToDictionary(p => p.Name);
+
+        foreach (var (name, oldProp) in oldProps)
+        {
+            if (newProps.TryGetValue(name, out var newProp))
+            {
+                if (!AreTypesEquivalent(oldProp.PropertyType, newProp.PropertyType))
+                {
+                    changes.Add(new TypeChange
+                    {
+                        Category = ChangeCategory.MemberTypeChanged,
+                        Severity = ChangeSeverity.High,
+                        TypeName = newType.Name,
+                        TypeFullName = newType.FullName,
+                        MemberName = name,
+                        FromType = GetTypeIdentifier(oldProp.PropertyType),
+                        ToType = GetTypeIdentifier(newProp.PropertyType),
+                        From = $"public {oldProp.PropertyType.Name} {name} {{ get; set; }}",
+                        To = $"public {newProp.PropertyType.Name} {name} {{ get; set; }}",
+                        Impact = $"Property type changed from {oldProp.PropertyType.Name} to {newProp.PropertyType.Name}",
+                        Migration = "Update code to handle new property type"
+                    });
+                }
+            }
+        }
+
+        // Compare fields
+        var oldFields = oldType.GetFields(flags).ToDictionary(f => f.Name);
+        var newFields = newType.GetFields(flags).ToDictionary(f => f.Name);
+
+        foreach (var (name, oldField) in oldFields)
+        {
+            if (newFields.TryGetValue(name, out var newField))
+            {
+                if (!AreTypesEquivalent(oldField.FieldType, newField.FieldType))
+                {
+                    changes.Add(new TypeChange
+                    {
+                        Category = ChangeCategory.MemberTypeChanged,
+                        Severity = ChangeSeverity.High,
+                        TypeName = newType.Name,
+                        TypeFullName = newType.FullName,
+                        MemberName = name,
+                        FromType = GetTypeIdentifier(oldField.FieldType),
+                        ToType = GetTypeIdentifier(newField.FieldType),
+                        From = $"public {oldField.FieldType.Name} {name}",
+                        To = $"public {newField.FieldType.Name} {name}",
+                        Impact = $"Field type changed from {oldField.FieldType.Name} to {newField.FieldType.Name}",
+                        Migration = "Update code to handle new field type"
+                    });
+                }
+            }
+        }
+
+        return changes;
+    }
+
+    /// <summary>
+    /// Detect when a type has been removed
+    /// </summary>
+    public TypeChange CreateTypeRemovedChange(Type type)
+    {
+        return new TypeChange
+        {
+            Category = ChangeCategory.TypeRemoved,
+            Severity = ChangeSeverity.High,
+            TypeName = type.Name,
+            TypeFullName = type.FullName,
+            Impact = "Type removed - all code using this type will break",
+            Migration = "Remove references to this type or find alternative"
+        };
+    }
+
+    /// <summary>
+    /// Detect when a type has been added
+    /// </summary>
+    public TypeChange CreateTypeAddedChange(Type type)
+    {
+        var documentation = _documentationProvider.GetDocumentation(type);
+
+        return new TypeChange
+        {
+            Category = ChangeCategory.TypeAdded,
+            Severity = ChangeSeverity.Low,
+            TypeName = type.Name,
+            TypeFullName = type.FullName,
+            Documentation = documentation,
+            Impact = "New type added - non-breaking change"
+        };
+    }
+
+    private List<TypeChange> CompareEnumValues(Type oldEnum, Type newEnum)
+    {
+        var changes = new List<TypeChange>();
+        var oldValues = Enum.GetNames(oldEnum).ToHashSet();
+        var newValues = Enum.GetNames(newEnum).ToHashSet();
+
+        foreach (var removed in oldValues.Except(newValues))
+        {
+            changes.Add(new TypeChange
+            {
+                Category = ChangeCategory.EnumValueRemoved,
+                Severity = ChangeSeverity.High,
+                TypeName = newEnum.Name,
+                TypeFullName = newEnum.FullName,
+                MemberName = removed,
+                Impact = $"Enum value {removed} removed - code using this value will break",
+                Migration = $"Replace usage of {removed} with alternative value"
+            });
+        }
+
+        foreach (var added in newValues.Except(oldValues))
+        {
+            var documentation = _documentationProvider.GetDocumentation(newEnum, added);
+
+            changes.Add(new TypeChange
+            {
+                Category = ChangeCategory.EnumValueAdded,
+                Severity = ChangeSeverity.Low,
+                TypeName = newEnum.Name,
+                TypeFullName = newEnum.FullName,
+                MemberName = added,
+                Documentation = documentation,
+                Impact = "New enum value added - may require handling in switch statements"
+            });
+        }
+
+        return changes;
+    }
+
+    private List<TypeChange> CompareMembers(Type oldType, Type newType)
+    {
+        var changes = new List<TypeChange>();
+
+        const BindingFlags flags = BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static | BindingFlags.DeclaredOnly;
+
+        // Get all members
+        var oldMembers = GetMembersDictionary(oldType, flags);
+        var newMembers = GetMembersDictionary(newType, flags);
+
+        // Find removed members
+        foreach (var (signature, member) in oldMembers)
+        {
+            if (!newMembers.ContainsKey(signature))
+            {
+                changes.Add(new TypeChange
+                {
+                    Category = ChangeCategory.MemberRemoved,
+                    Severity = ChangeSeverity.High,
+                    TypeName = newType.Name,
+                    TypeFullName = newType.FullName,
+                    MemberName = member.Name,
+                    From = signature,
+                    Impact = $"Member {member.Name} removed - code using it will break",
+                    Migration = $"Remove calls to {member.Name} or find alternative"
+                });
+            }
+        }
+
+        // Find added members
+        foreach (var (signature, member) in newMembers)
+        {
+            if (!oldMembers.ContainsKey(signature))
+            {
+                var documentation = _documentationProvider.GetDocumentation(member);
+
+                changes.Add(new TypeChange
+                {
+                    Category = ChangeCategory.MemberAdded,
+                    Severity = ChangeSeverity.Low,
+                    TypeName = newType.Name,
+                    TypeFullName = newType.FullName,
+                    MemberName = member.Name,
+                    To = signature,
+                    Documentation = documentation,
+                    Impact = "New member added - non-breaking change"
+                });
+            }
+        }
+
+        // Find modified members (same name but different signature)
+        var oldMethodsByName = oldType.GetMethods(flags).GroupBy(m => m.Name).ToDictionary(g => g.Key, g => g.ToList());
+        var newMethodsByName = newType.GetMethods(flags).GroupBy(m => m.Name).ToDictionary(g => g.Key, g => g.ToList());
+
+        foreach (var (name, oldMethods) in oldMethodsByName)
+        {
+            if (newMethodsByName.TryGetValue(name, out var newMethods))
+            {
+                // Check for changes in overloads
+                changes.AddRange(CompareMethodOverloads(oldMethods, newMethods, newType));
+            }
+        }
+
+        // Check for property and field type changes
+        changes.AddRange(ComparePropertiesAndFields(oldType, newType, flags));
+
+        // Post-process to detect compatible overloads (methods with optional parameters)
+        DetectCompatibleOverloads(changes, oldType, newType, flags);
+
+        return changes;
+    }
+
+    private List<TypeChange> CompareMethodOverloads(List<MethodInfo> oldMethods, List<MethodInfo> newMethods, Type type)
+    {
+        var changes = new List<TypeChange>();
+
+        foreach (var oldMethod in oldMethods)
+        {
+            var oldSignature = GetMethodSignature(oldMethod);
+            var matchingNew = newMethods.FirstOrDefault(m => GetMethodSignature(m) == oldSignature);
+
+            if (matchingNew != null)
+            {
+                // Same signature exists - check for other changes
+                if (!AreTypesEquivalent(oldMethod.ReturnType, matchingNew.ReturnType))
+                {
+                    changes.Add(new TypeChange
+                    {
+                        Category = ChangeCategory.ReturnTypeChanged,
+                        Severity = ChangeSeverity.High,
+                        TypeName = type.Name,
+                        TypeFullName = type.FullName,
+                        MemberName = oldMethod.Name,
+                        FromType = oldMethod.ReturnType.Name,
+                        ToType = matchingNew.ReturnType.Name,
+                        Impact = "Return type changed - may break code expecting original type",
+                        Migration = "Update code to handle new return type"
+                    });
+                }
+
+                // Check for parameter changes
+                var oldParams = oldMethod.GetParameters();
+                var newParams = matchingNew.GetParameters();
+
+                if (oldParams.Length != newParams.Length)
+                {
+                    changes.Add(new TypeChange
+                    {
+                        Category = ChangeCategory.MethodSignatureChanged,
+                        Severity = ChangeSeverity.High,
+                        TypeName = type.Name,
+                        TypeFullName = type.FullName,
+                        MemberName = oldMethod.Name,
+                        From = GetMethodSignatureDetailed(oldMethod),
+                        To = GetMethodSignatureDetailed(matchingNew),
+                        Impact = "Method parameter count changed - breaks all calls",
+                        Migration = "Update all method calls to match new signature"
+                    });
+                }
+                else
+                {
+                    // Check for parameter type changes
+                    for (int i = 0; i < oldParams.Length; i++)
+                    {
+                        if (!AreTypesEquivalent(oldParams[i].ParameterType, newParams[i].ParameterType))
+                        {
+                            changes.Add(new TypeChange
+                            {
+                                Category = ChangeCategory.ParameterTypeChanged,
+                                Severity = ChangeSeverity.High,
+                                TypeName = type.Name,
+                                TypeFullName = type.FullName,
+                                MemberName = oldMethod.Name,
+                                From = $"{oldParams[i].Name}: {oldParams[i].ParameterType.Name}",
+                                To = $"{newParams[i].Name}: {newParams[i].ParameterType.Name}",
+                                FromType = GetTypeIdentifier(oldParams[i].ParameterType),
+                                ToType = GetTypeIdentifier(newParams[i].ParameterType),
+                                Impact = "Parameter type changed - breaks method calls",
+                                Migration = "Update method calls to pass correct parameter type"
+                            });
+                        }
+                    }
+                }
+
+                if (oldMethod.IsVirtual && !matchingNew.IsVirtual)
+                {
+                    changes.Add(new TypeChange
+                    {
+                        Category = ChangeCategory.VirtualRemoved,
+                        Severity = ChangeSeverity.High,
+                        TypeName = type.Name,
+                        TypeFullName = type.FullName,
+                        MemberName = oldMethod.Name,
+                        Impact = "Method no longer virtual - overrides in derived classes will break",
+                        Migration = "Remove overrides or use alternative extensibility pattern"
+                    });
+                }
+
+                // Check accessibility
+                if (GetAccessibilityLevel(oldMethod) > GetAccessibilityLevel(matchingNew))
+                {
+                    changes.Add(new TypeChange
+                    {
+                        Category = ChangeCategory.AccessibilityReduced,
+                        Severity = ChangeSeverity.High,
+                        TypeName = type.Name,
+                        TypeFullName = type.FullName,
+                        MemberName = oldMethod.Name,
+                        Impact = "Method accessibility reduced - previously accessible code may break",
+                        Migration = "Review access to this method"
+                    });
+                }
+                else if (GetAccessibilityLevel(oldMethod) < GetAccessibilityLevel(matchingNew))
+                {
+                    changes.Add(new TypeChange
+                    {
+                        Category = ChangeCategory.AccessibilityExpanded,
+                        Severity = ChangeSeverity.Low,
+                        TypeName = type.Name,
+                        TypeFullName = type.FullName,
+                        MemberName = oldMethod.Name,
+                        Impact = "Method accessibility expanded - non-breaking change"
+                    });
+                }
+
+                // Check for obsolete attribute
+                if (!oldMethod.GetCustomAttributes<ObsoleteAttribute>().Any() &&
+                    matchingNew.GetCustomAttributes<ObsoleteAttribute>().Any())
+                {
+                    changes.Add(new TypeChange
+                    {
+                        Category = ChangeCategory.MemberObsoleted,
+                        Severity = ChangeSeverity.Medium,
+                        TypeName = type.Name,
+                        TypeFullName = type.FullName,
+                        MemberName = oldMethod.Name,
+                        Impact = "Member marked as obsolete - should be replaced",
+                        Migration = "Find replacement API as indicated by obsolete message"
+                    });
+                }
+            }
+        }
+
+        return changes;
+    }
+
+    private Dictionary<string, MemberInfo> GetMembersDictionary(Type type, BindingFlags flags)
+    {
+        var members = new Dictionary<string, MemberInfo>();
+
+        foreach (var method in type.GetMethods(flags).Where(m => !m.IsSpecialName))
+        {
+            var signature = GetMethodSignature(method);
+            members[signature] = method;
+        }
+
+        foreach (var property in type.GetProperties(flags))
+        {
+            var signature = $"Property:{property.Name}:{property.PropertyType.Name}";
+            members[signature] = property;
+        }
+
+        foreach (var field in type.GetFields(flags))
+        {
+            var signature = $"Field:{field.Name}:{field.FieldType.Name}";
+            members[signature] = field;
+        }
+
+        foreach (var evt in type.GetEvents(flags))
+        {
+            var signature = $"Event:{evt.Name}";
+            members[signature] = evt;
+        }
+
+        return members;
+    }
+
+    private string GetMethodSignature(MethodInfo method)
+    {
+        var sb = new StringBuilder();
+        sb.Append(method.Name);
+        sb.Append('(');
+
+        var parameters = method.GetParameters();
+        for (int i = 0; i < parameters.Length; i++)
+        {
+            if (i > 0) sb.Append(',');
+            sb.Append(parameters[i].ParameterType.Name);
+        }
+
+        sb.Append(')');
+        return sb.ToString();
+    }
+
+    private string GetMethodSignatureDetailed(MethodInfo method)
+    {
+        var sb = new StringBuilder();
+        sb.Append(method.Name);
+        sb.Append('(');
+
+        var parameters = method.GetParameters();
+        for (int i = 0; i < parameters.Length; i++)
+        {
+            if (i > 0) sb.Append(", ");
+            sb.Append($"{parameters[i].ParameterType.Name} {parameters[i].Name}");
+        }
+
+        sb.Append(')');
+        return sb.ToString();
+    }
+
+    private int GetAccessibilityLevel(MethodInfo method)
+    {
+        if (method.IsPublic) return 3;
+        if (method.IsFamily) return 2;
+        if (method.IsAssembly) return 1;
+        return 0;
+    }
+
+    /// <summary>
+    /// Compare types ignoring assembly version.
+    /// This prevents false positives when only the assembly version changes (e.g., 22.6.0.0 → 22.7.0.0)
+    /// but the actual type structure remains the same.
+    /// </summary>
+    private bool AreTypesEquivalent(Type? type1, Type? type2)
+    {
+        if (type1 == null && type2 == null) return true;
+        if (type1 == null || type2 == null) return false;
+
+        // For generic types, compare the generic type definition only (avoid recursion)
+        if (type1.IsGenericType && type2.IsGenericType)
+        {
+            var def1 = type1.GetGenericTypeDefinition();
+            var def2 = type2.GetGenericTypeDefinition();
+
+            // Compare generic definitions by name and assembly
+            if (def1.Namespace != def2.Namespace || def1.Name != def2.Name)
+                return false;
+
+            if (def1.Assembly.GetName().Name != def2.Assembly.GetName().Name)
+                return false;
+
+            // Compare number of generic arguments
+            var args1 = type1.GetGenericArguments();
+            var args2 = type2.GetGenericArguments();
+
+            return args1.Length == args2.Length;
+        }
+
+        // For arrays, compare element types
+        if (type1.IsArray && type2.IsArray)
+        {
+            return AreTypesEquivalent(type1.GetElementType(), type2.GetElementType());
+        }
+
+        // Compare namespace, name, and assembly name (without version)
+        return type1.Namespace == type2.Namespace &&
+               type1.Name == type2.Name &&
+               type1.Assembly.GetName().Name == type2.Assembly.GetName().Name;
+    }
+
+    /// <summary>
+    /// Get type identifier without assembly version (for comparison and display).
+    /// Returns format: "Namespace.TypeName, AssemblyName" without version info.
+    /// </summary>
+    private string GetTypeIdentifier(Type type)
+    {
+        var assemblyName = type.Assembly.GetName().Name;
+
+        // Handle generic types
+        if (type.IsGenericType)
+        {
+            var genericDef = type.GetGenericTypeDefinition();
+            var genericArgs = type.GetGenericArguments();
+            var argNames = string.Join(", ", genericArgs.Select(GetTypeIdentifier));
+            return $"{genericDef.Namespace}.{genericDef.Name}[{argNames}], {assemblyName}";
+        }
+
+        return $"{type.FullName}, {assemblyName}";
+    }
+
+    /// <summary>
+    /// Post-process changes to detect compatible method overloads (methods with optional parameters).
+    /// Converts "MemberRemoved + MemberAdded" into "MethodOverloadAdded" when the new method
+    /// is backward-compatible (same signature + optional parameters).
+    /// </summary>
+    private void DetectCompatibleOverloads(List<TypeChange> changes, Type oldType, Type newType, BindingFlags flags)
+    {
+        // Find all method-related removals and additions
+        var removedMethods = changes
+            .Where(c => c.Category == ChangeCategory.MemberRemoved && c.MemberName != null)
+            .ToList();
+
+        var addedMethods = changes
+            .Where(c => c.Category == ChangeCategory.MemberAdded && c.MemberName != null)
+            .ToList();
+
+        var changesToRemove = new List<TypeChange>();
+        var changesToAdd = new List<TypeChange>();
+
+        // Process each removed method
+        foreach (var removed in removedMethods)
+        {
+            // Find the old method by signature (use signature without parameter names)
+            var oldMethod = oldType.GetMethods(flags)
+                .FirstOrDefault(m => GetMethodSignature(m) == removed.From);
+            if (oldMethod == null) continue;
+
+            // Look for compatible new method with same name
+            foreach (var added in addedMethods.Where(a => a.MemberName == removed.MemberName))
+            {
+                var newMethod = newType.GetMethods(flags)
+                    .FirstOrDefault(m => GetMethodSignature(m) == added.To);
+                if (newMethod == null) continue;
+
+                // Check if this is a compatible overload
+                if (IsCompatibleOverload(oldMethod, newMethod))
+                {
+                    // Mark for removal
+                    changesToRemove.Add(removed);
+                    changesToRemove.Add(added);
+
+                    // Add replacement change
+                    changesToAdd.Add(new TypeChange
+                    {
+                        Category = ChangeCategory.MethodOverloadAdded,
+                        Severity = ChangeSeverity.Low,
+                        TypeName = newType.Name,
+                        TypeFullName = newType.FullName,
+                        MemberName = newMethod.Name,
+                        From = removed.From,
+                        To = added.To,
+                        Impact = "Compatible method overload added with optional parameters - non-breaking change",
+                        Migration = "No changes required - existing calls will continue to work"
+                    });
+
+                    break; // Found match, move to next removed
+                }
+            }
+        }
+
+        // Apply changes
+        foreach (var change in changesToRemove)
+        {
+            changes.Remove(change);
+        }
+
+        changes.AddRange(changesToAdd);
+    }
+
+    /// <summary>
+    /// Check if a new method is a compatible overload of an old method.
+    /// Compatible means: same return type, same first N parameters, and all additional parameters have default values.
+    /// </summary>
+    private bool IsCompatibleOverload(MethodInfo oldMethod, MethodInfo newMethod)
+    {
+        // Must have same return type
+        if (!AreTypesEquivalent(oldMethod.ReturnType, newMethod.ReturnType))
+            return false;
+
+        var oldParams = oldMethod.GetParameters();
+        var newParams = newMethod.GetParameters();
+
+        // New method must have at least as many parameters
+        if (newParams.Length < oldParams.Length)
+            return false;
+
+        // If same parameter count, not a compatible overload (likely a different kind of change)
+        if (newParams.Length == oldParams.Length)
+            return false;
+
+        // First N parameters must match in type and position
+        for (int i = 0; i < oldParams.Length; i++)
+        {
+            if (!AreTypesEquivalent(oldParams[i].ParameterType, newParams[i].ParameterType))
+                return false;
+        }
+
+        // All additional parameters must have default values
+        for (int i = oldParams.Length; i < newParams.Length; i++)
+        {
+            if (!newParams[i].HasDefaultValue)
+                return false;
+        }
+
+        return true;
+    }
+}

--- a/NugetMcpServer/Tools/ComparePackageVersionsTool.cs
+++ b/NugetMcpServer/Tools/ComparePackageVersionsTool.cs
@@ -1,0 +1,92 @@
+using System;
+using System.ComponentModel;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using ModelContextProtocol;
+using ModelContextProtocol.Server;
+using NuGetMcpServer.Common;
+using NuGetMcpServer.Extensions;
+using NuGetMcpServer.Services;
+using static NuGetMcpServer.Extensions.ExceptionHandlingExtensions;
+
+namespace NuGetMcpServer.Tools;
+
+/// <summary>
+/// MCP tool for comparing two versions of a NuGet package
+/// </summary>
+[McpServerToolType]
+public class ComparePackageVersionsTool : McpToolBase<ComparePackageVersionsTool>
+{
+    private readonly PackageComparisonService _comparisonService;
+
+    public ComparePackageVersionsTool(
+        ILogger<ComparePackageVersionsTool> logger,
+        NuGetPackageService packageService,
+        PackageComparisonService comparisonService)
+        : base(logger, packageService)
+    {
+        _comparisonService = comparisonService;
+    }
+
+    [McpServerTool]
+    [Description("Compares two versions of a NuGet package and detects all API changes including breaking changes, additions, and removals.")]
+    public Task<ComparisonResult> compare_package_versions(
+        [Description("NuGet package ID")] string packageId,
+        [Description("Older version to compare from")] string fromVersion,
+        [Description("Newer version to compare to")] string toVersion,
+        [Description("Optional filter for TYPE NAMES (classes, structs, records, interfaces). Supports wildcards: '*Controller' matches types ending with Controller, '*Message*' matches types containing Message. NOTE: This filters by type names, NOT by field/property names.")] string? typeNameFilter = null,
+        [Description("Optional filter for MEMBER NAMES (properties, fields, methods). Supports wildcards: '*Id' matches members ending with Id, 'Calculate*' matches members starting with Calculate. Supports OR via '|': 'StarCount|TopicId'. Works independently from typeNameFilter.")] string? memberNameFilter = null,
+        [Description("If true, returns only breaking changes (high severity). Non-breaking changes and additions are excluded. Default: false")] bool breakingChangesOnly = false,
+        [Description("Maximum changes to return per category (default: 100)")] int maxChangesPerCategory = 100,
+        [Description("Progress notification for long-running operations")] IProgress<ProgressNotificationValue>? progress = null)
+    {
+        using ProgressNotifier progressNotifier = new ProgressNotifier(progress);
+
+        return ExecuteWithLoggingAsync(
+            () => CompareVersionsCore(packageId, fromVersion, toVersion, typeNameFilter, memberNameFilter, breakingChangesOnly, maxChangesPerCategory, progressNotifier),
+            Logger,
+            "Error comparing package versions");
+    }
+
+    private async Task<ComparisonResult> CompareVersionsCore(
+        string packageId,
+        string fromVersion,
+        string toVersion,
+        string? typeNameFilter,
+        string? memberNameFilter,
+        bool breakingChangesOnly,
+        int maxChangesPerCategory,
+        IProgressNotifier progress)
+    {
+        if (string.IsNullOrWhiteSpace(packageId))
+            throw new ArgumentNullException(nameof(packageId));
+
+        if (string.IsNullOrWhiteSpace(fromVersion))
+            throw new ArgumentNullException(nameof(fromVersion));
+
+        if (string.IsNullOrWhiteSpace(toVersion))
+            throw new ArgumentNullException(nameof(toVersion));
+
+        Logger.LogInformation(
+            "Comparing package {PackageId} versions {FromVersion} -> {ToVersion}",
+            packageId, fromVersion, toVersion);
+
+        progress.ReportMessage($"Starting comparison of {packageId} v{fromVersion} -> v{toVersion}");
+
+        var result = await _comparisonService.CompareVersionsAsync(
+            packageId,
+            fromVersion,
+            toVersion,
+            typeNameFilter,
+            memberNameFilter,
+            breakingChangesOnly,
+            maxChangesPerCategory,
+            System.Threading.CancellationToken.None);
+
+        progress.ReportMessage(
+            $"Comparison complete: {result.Summary.TotalChanges} changes detected " +
+            $"({result.Summary.BreakingChanges} breaking, {result.Summary.Additions} additions, {result.Summary.Removals} removals)");
+
+        return result;
+    }
+}

--- a/TestLibraries/TestLibrary.V1/TestClasses.cs
+++ b/TestLibraries/TestLibrary.V1/TestClasses.cs
@@ -1,0 +1,186 @@
+namespace TestLibrary;
+
+// === BREAKING CHANGES ===
+
+// 1. Type will be REMOVED in V2
+public class ClassToRemove
+{
+    public void SomeMethod() { }
+}
+
+// 2. Member type changes (int → long)
+public class ClassWithMemberTypeChange
+{
+    public int Amount { get; set; }
+    public int? NullableAmount { get; set; }
+}
+
+// 3. Member removed
+public class ClassWithMemberRemoval
+{
+    public void MethodToRemove() { }
+    public string PropertyToRemove { get; set; } = "";
+    public int FieldToRemove;
+}
+
+// 4. Method signature changed
+public class ClassWithMethodSignatureChange
+{
+    public void MethodWithParamRemoval(int x, int y) { }
+    public void MethodWithParamTypeChange(int x) { }
+    public int MethodWithReturnTypeChange() => 0;
+}
+
+// 5. Virtual removed
+public class ClassWithVirtualRemoval
+{
+    public virtual void VirtualMethod() { }
+}
+
+// 6. Base class changed
+public class BaseClass1 { }
+public class BaseClass2 { }
+public class ClassWithBaseChange : BaseClass1 { }
+
+// 7. Interface removed
+public interface IInterface1 { }
+public interface IInterface2 { }
+public class ClassWithInterfaceRemoval : IInterface1, IInterface2 { }
+
+// 8. Accessibility reduced (public → internal)
+public class ClassWithAccessibilityReduction
+{
+    public void PublicMethod() { }
+}
+
+// 9. Sealed added
+public class ClassToBeSealed { }
+
+// 10. Abstract added
+public class ClassToBeAbstract { }
+
+// 11. Generic parameters changed
+public class GenericClass<T> { }
+
+// 12. Enum value removed
+public enum EnumWithValueRemoval
+{
+    Value1,
+    Value2,  // Will be removed in V2
+    Value3
+}
+
+// === NON-BREAKING CHANGES ===
+
+// 13. Member obsoleted
+public class ClassWithObsolete
+{
+    public void MethodToObsolete() { }
+}
+
+// 14. Accessibility expanded (internal → public)
+public class ClassWithAccessibilityExpansion
+{
+    internal void InternalMethod() { }
+}
+
+// 15. Parameter default changed
+public class ClassWithDefaultChange
+{
+    public void MethodWithDefault(int x = 5) { }
+}
+
+// === ADDITIONS ===
+
+// 16. New members will be added
+public class ClassWithAdditions
+{
+    public void ExistingMethod() { }
+}
+
+// 17. New interface will be added
+public class ClassWithInterfaceAddition { }
+
+// 18. New enum value will be added
+public enum EnumWithValueAddition
+{
+    Value1,
+    Value2
+}
+
+// === DELEGATES ===
+public delegate void TestDelegate(int x);
+
+// === STRUCTS ===
+public struct TestStruct
+{
+    public int Value;
+}
+
+// === MEMBER NAME FILTER TESTING ===
+
+// 19. For testing memberNameFilter with wildcards and OR
+public class ClassForMemberFilter
+{
+    // Fields ending with "Count" - testing *Count wildcard
+    public int StarCount { get; set; }
+    public int MessageCount { get; set; }
+
+    // Fields ending with "Id" - testing *Id wildcard
+    public int TopicId;
+    public string UserId { get; set; } = "";
+
+    // Methods starting with "Calculate" - testing Calculate* wildcard
+    public int CalculateTotal() => 0;
+    public void CalculateSum() { }
+
+    // Methods starting with "Get" - testing Get* wildcard
+    public string GetValue() => "";
+    public void GetData() { }
+
+    // Property for exact match testing
+    public string Amount { get; set; } = "";
+}
+
+// 20. Another class to test that memberFilter works across types
+public class AnotherClassWithMembers
+{
+    public int StarCount { get; set; }  // Same name as in ClassForMemberFilter
+    public void CalculateTotal() { }    // Same name as in ClassForMemberFilter
+}
+
+// === OPTIONAL PARAMETERS TESTING ===
+
+// 21. Compatible overload - method with optional parameters added (NON-breaking)
+public class ClassWithOptionalParamsAdded
+{
+    // V1: Simple method
+    public void SendMessage(string text) { }
+
+    // V1: Method with two params
+    public int Calculate(int a, int b) => a + b;
+
+    // V1: Method with return type
+    public string FormatText(string input) => input;
+}
+
+// 22. Incompatible change - method with required parameters added (BREAKING)
+public class ClassWithRequiredParamsAdded
+{
+    // V1: Simple method - will be REPLACED with version requiring more params
+    public void ProcessData(int value) { }
+}
+
+// 23. True new overload - old signature remains (NON-breaking)
+public class ClassWithTrueOverload
+{
+    // V1: This will remain in V2, but additional overload will be added
+    public void Execute(string command) { }
+}
+
+// 24. Method parameter reordering (BREAKING)
+public class ClassWithParamReordering
+{
+    // V1: params in one order
+    public void ConfigureSettings(string name, int value, bool enabled) { }
+}

--- a/TestLibraries/TestLibrary.V1/TestLibrary.V1.csproj
+++ b/TestLibraries/TestLibrary.V1/TestLibrary.V1.csproj
@@ -1,0 +1,6 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+</Project>

--- a/TestLibraries/TestLibrary.V2/TestClasses.cs
+++ b/TestLibraries/TestLibrary.V2/TestClasses.cs
@@ -1,0 +1,204 @@
+using System;
+
+namespace TestLibrary;
+
+// === BREAKING CHANGES ===
+
+// 1. ClassToRemove - DELETED
+
+// 2. Member type changes (int → long) ✓
+public class ClassWithMemberTypeChange
+{
+    public long Amount { get; set; }  // BREAKING: int → long
+    public long? NullableAmount { get; set; }  // BREAKING: int? → long?
+}
+
+// 3. Member removed ✓
+public class ClassWithMemberRemoval
+{
+    // MethodToRemove - DELETED
+    // PropertyToRemove - DELETED
+    // FieldToRemove - DELETED
+}
+
+// 4. Method signature changed ✓
+public class ClassWithMethodSignatureChange
+{
+    public void MethodWithParamRemoval(int x) { }  // BREAKING: parameter removed
+    public void MethodWithParamTypeChange(long x) { }  // BREAKING: int → long
+    public long MethodWithReturnTypeChange() => 0;  // BREAKING: int → long
+}
+
+// 5. Virtual removed ✓
+public class ClassWithVirtualRemoval
+{
+    public void VirtualMethod() { }  // BREAKING: no longer virtual
+}
+
+// 6. Base class changed ✓
+public class ClassWithBaseChange : BaseClass2 { }  // BREAKING: BaseClass1 → BaseClass2
+
+// 7. Interface removed ✓
+public class ClassWithInterfaceRemoval : IInterface1 { }  // BREAKING: IInterface2 removed
+
+// 8. Accessibility reduced ✓
+public class ClassWithAccessibilityReduction
+{
+    internal void PublicMethod() { }  // BREAKING: public → internal
+}
+
+// 9. Sealed added ✓
+public sealed class ClassToBeSealed { }  // BREAKING: sealed added
+
+// 10. Abstract added ✓
+public abstract class ClassToBeAbstract { }  // BREAKING: abstract added
+
+// 11. Generic parameters changed ✓
+public class GenericClass<T, U> { }  // BREAKING: <T> → <T, U>
+
+// 12. Enum value removed ✓
+public enum EnumWithValueRemoval
+{
+    Value1,
+    // Value2 - DELETED
+    Value3
+}
+
+// === NON-BREAKING CHANGES ===
+
+// 13. Member obsoleted ✓
+public class ClassWithObsolete
+{
+    [Obsolete("Use NewMethod instead")]
+    public void MethodToObsolete() { }  // NON-BREAKING: [Obsolete] added
+}
+
+// 14. Accessibility expanded ✓
+public class ClassWithAccessibilityExpansion
+{
+    public void InternalMethod() { }  // NON-BREAKING: internal → public
+}
+
+// 15. Parameter default changed ✓
+public class ClassWithDefaultChange
+{
+    public void MethodWithDefault(int x = 10) { }  // NON-BREAKING: default 5 → 10
+}
+
+// === ADDITIONS ===
+
+// 16. New members added ✓
+public class ClassWithAdditions
+{
+    public void ExistingMethod() { }
+    public void NewMethod() { }  // ADDITION
+    public string NewProperty { get; set; } = "";  // ADDITION
+    public int NewField;  // ADDITION
+    public void ExistingMethod(int overload) { }  // ADDITION: method overload
+    public void MethodWithOptionalParam(int x = 0) { }  // ADDITION: optional parameter
+}
+
+// 17. New interface added ✓
+public interface INewInterface { }
+public class ClassWithInterfaceAddition : INewInterface { }  // ADDITION
+
+// 18. New enum value added ✓
+public enum EnumWithValueAddition
+{
+    Value1,
+    Value2,
+    Value3  // ADDITION
+}
+
+// === NEW TYPES (ADDITIONS) ===
+public class NewClass { }  // ADDITION
+public interface IAddedInterface { }  // ADDITION
+public enum NewEnum { Value1 }  // ADDITION
+public delegate void NewDelegate(int x);  // ADDITION
+public struct NewStruct { public int Value; }  // ADDITION
+
+// === EXTENSION METHODS ===
+public static class ExtensionMethods
+{
+    public static void NewExtension(this string s) { }  // ADDITION
+}
+
+// Keep existing from V1
+public class BaseClass1 { }
+public class BaseClass2 { }
+public interface IInterface1 { }
+public interface IInterface2 { }
+public delegate void TestDelegate(int x);
+public struct TestStruct { public int Value; }
+
+// === MEMBER NAME FILTER TESTING ===
+
+// 19. For testing memberNameFilter ✓
+public class ClassForMemberFilter
+{
+    // BREAKING: int → long
+    public long StarCount { get; set; }     // CHANGED: int → long
+    public int MessageCount { get; set; }   // unchanged
+
+    // BREAKING: int → string
+    public string TopicId = "";             // CHANGED: int → string
+    public string UserId { get; set; } = "";  // unchanged
+
+    // BREAKING: method removed
+    // CalculateTotal() REMOVED
+    public void CalculateSum() { }          // unchanged
+
+    // BREAKING: return type changed
+    public int GetValue() => 0;             // CHANGED: string → int
+    public void GetData() { }               // unchanged
+
+    // BREAKING: property removed
+    // Amount property REMOVED
+}
+
+// 20. Another class to test memberFilter across types ✓
+public class AnotherClassWithMembers
+{
+    public long StarCount { get; set; }  // CHANGED: int → long
+    public void CalculateTotal() { }     // unchanged
+}
+
+// === OPTIONAL PARAMETERS TESTING ===
+
+// 21. Compatible overload - method with optional parameters added (NON-breaking) ✓
+public class ClassWithOptionalParamsAdded
+{
+    // V2: Method with optional parameter added - COMPATIBLE with V1 (non-breaking)
+    public void SendMessage(string text, int? threadId = null) { }
+
+    // V2: Method with multiple optional params added - COMPATIBLE (non-breaking)
+    public int Calculate(int a, int b, int c = 0, int d = 0) => a + b + c + d;
+
+    // V2: Method with optional param - COMPATIBLE (non-breaking)
+    public string FormatText(string input, bool uppercase = false) =>
+        uppercase ? input.ToUpper() : input;
+}
+
+// 22. Incompatible change - method with required parameters added (BREAKING) ✓
+public class ClassWithRequiredParamsAdded
+{
+    // V2: Method with required parameter added - INCOMPATIBLE (breaking)
+    public void ProcessData(int value, string mode) { }  // BREAKING: requires 'mode'
+}
+
+// 23. True new overload - old signature remains (NON-breaking) ✓
+public class ClassWithTrueOverload
+{
+    // V2: Old signature STILL exists
+    public void Execute(string command) { }
+
+    // V2: NEW overload added (non-breaking)
+    public void Execute(string command, int timeout) { }
+}
+
+// 24. Method parameter reordering (BREAKING) ✓
+public class ClassWithParamReordering
+{
+    // V2: params reordered - BREAKING
+    public void ConfigureSettings(int value, string name, bool enabled) { }
+}

--- a/TestLibraries/TestLibrary.V2/TestLibrary.V2.csproj
+++ b/TestLibraries/TestLibrary.V2/TestLibrary.V2.csproj
@@ -1,0 +1,6 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
  feat: add compare_package_versions tool with breaking change detection
  - Compare two NuGet package versions via Reflection
  - Detect 27 categories of changes: breaking, non-breaking, additions
  - Support typeNameFilter (wildcard filter by type names)
  - Support memberNameFilter (wildcard filter by member names with OR)
  - Support breakingChangesOnly flag to reduce token usage
  - Support maxChangesPerCategory limit with truncation
  - Fix false positives from assembly version differences
  - Detect compatible overloads with optional parameters